### PR TITLE
Update api.py - Add detection of TVHeadend

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -49,7 +49,8 @@ def get_ffmpeg_version() -> Optional[str]:
 def get_content_type(url: str) -> str:
     """Determine content type based on URL extension"""
     url_lower = url.lower()
-    if url_lower.endswith('.ts'):
+    # profile=pass is set by the TVHeadend "Pass" Profile. Maybe needs more tuning if the Source doesnt deliver MPEG-TS
+    if url_lower.endswith('.ts') or url_lower.endswith('?profile=pass'):
         return 'video/mp2t'
     elif url_lower.endswith('.m3u8'):
         return 'application/vnd.apple.mpegurl'

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -954,7 +954,8 @@ class StreamManager:
             await self.cleanup_client(client_id)
 
         # Determine content type
-        if current_url.endswith('.ts') or '/live/' in current_url:
+        # profile=pass is set by the TVHeadend "Pass" Profile. Maybe needs more tuning if the Source doesnt deliver MPEG-TS
+        if current_url.endswith('.ts') or '/live/' in current_url or current_url.endswith('?profile=pass'):
             content_type = "video/mp2t"
         elif current_url.endswith('.mp4'):
             content_type = "video/mp4"


### PR DESCRIPTION
Detects the Container of TVHeadend if the default profile "pass" is in use and sets the right Content-Type. Befor this fix "application/octet-stream" was used which causes trouble on other Services like Jellyfin
Maybe this needs some more stuff if TVheadend doese not Output MPEG-TS. This can be different on various tvh sources. Tested with DVB-S(2) Sat-IP Tuner.

Fixes https://github.com/sparkison/m3u-proxy/issues/21

Before:
```
curl -I http://10.10.10.3:36400/m3u-proxy/stream/3f53a5f45d11183d9a517731abcc214e
HTTP/1.1 200 OK
Server: nginx/1.26.3
Date: Wed, 26 Nov 2025 13:20:15 GMT
**Content-Type: application/octet-stream**
Content-Length: 0
Connection: keep-alive
accept-ranges: bytes
cache-control: no-cache, no-store, must-revalidate
pragma: no-cache
expires: 0
access-control-allow-origin: *
access-control-allow-methods: GET, HEAD, OPTIONS
access-control-allow-headers: *
access-control-expose-headers: *
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Length,Content-Range
Access-Control-Allow-Headers: Range,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type
Access-Control-Allow-Methods: GET, HEAD, OPTIONS
```

After:
```
curl -I http://10.10.10.3:36400/m3u-proxy/stream/3f53a5f45d11183d9a517731abcc214e
HTTP/1.1 200 OK
Server: nginx/1.26.3
Date: Wed, 26 Nov 2025 16:31:57 GMT
**Content-Type: video/mp2t**
Content-Length: 0
Connection: keep-alive
accept-ranges: bytes
cache-control: no-cache, no-store, must-revalidate
pragma: no-cache
expires: 0
access-control-allow-origin: *
access-control-allow-methods: GET, HEAD, OPTIONS
access-control-allow-headers: *
access-control-expose-headers: *
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Length,Content-Range
Access-Control-Allow-Headers: Range,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type
Access-Control-Allow-Methods: GET, HEAD, OPTIONS
```