### PR TITLE
Remove Content-Length header for stream generation

### DIFF
--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -1199,6 +1199,8 @@ class StreamManager:
             # Only include Content-Length for non-live or non-strict streams
             headers["Content-Length"] = provider_content_length
 
+        headers.pop("Content-Length", None)
+
         # Create new generator that yields the first chunk then continues with the rest
         async def generate_with_first_chunk():
             yield first_chunk


### PR DESCRIPTION
Remove Content-Length header before generating stream.

Now you cannot see any issue, but the botton remove stream is not working if the user is watching something, it is not kicking him out