### PR TITLE
feat: Include metadata in all stream events for provider profile tracking

### DIFF
--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -476,7 +476,8 @@ class StreamManager:
             "user_agent": user_agent,
             "ip_address": ip_address,
             "username": username,
-            "stream_client_count": len(self.stream_clients[effective_stream_id]) if effective_stream_id in self.stream_clients else 0
+            "stream_client_count": len(self.stream_clients[effective_stream_id]) if effective_stream_id in self.stream_clients else 0,
+            "metadata": self.streams[effective_stream_id].metadata if effective_stream_id in self.streams else {}
         })
 
         return client_info
@@ -504,7 +505,8 @@ class StreamManager:
             await self._emit_event("CLIENT_DISCONNECTED", stream_id or "unknown", {
                 "client_id": client_id,
                 "bytes_served": client_info.bytes_served,
-                "segments_served": client_info.segments_served
+                "segments_served": client_info.segments_served,
+                "metadata": self.streams[stream_id].metadata if stream_id and stream_id in self.streams else {}
             })
             # Notify pooled manager (if any) that this client is gone so shared
             # transcoding processes can be cleaned up when no clients remain.
@@ -628,7 +630,8 @@ class StreamManager:
                         await self._emit_event("STREAM_STARTED", stream_id, {
                             "url": active_url,
                             "client_id": client_id,
-                            "mode": "direct_proxy"
+                            "mode": "direct_proxy",
+                            "metadata": stream_info.metadata
                         })
                     else:
                         logger.info(
@@ -1006,7 +1009,8 @@ class StreamManager:
                         await self._emit_event("STREAM_STOPPED", stream_id, {
                             "client_id": client_id,
                             "bytes_served": bytes_served,
-                            "chunks_served": chunk_count
+                            "chunks_served": chunk_count,
+                            "metadata": stream_info.metadata
                         })
                         break  # Exit the failover loop
                     # else: failover event was set, continue to next iteration
@@ -2453,7 +2457,8 @@ class StreamManager:
                 # Emit stream_stopped event before removing the stream
                 await self._emit_event("STREAM_STOPPED", stream_id, {
                     "reason": "inactive_timeout",
-                    "timeout_seconds": self.stream_timeout
+                    "timeout_seconds": self.stream_timeout,
+                    "metadata": stream_info.metadata
                 })
 
                 del self.streams[stream_id]


### PR DESCRIPTION
## Summary

This PR adds the `metadata` field to all stream-related webhook events, enabling consistent provider profile tracking across the entire stream lifecycle.

## Problem

Currently, the `metadata` field (which contains important information like `provider_profile_id`) is only included in some events. When m3u-editor needs to track provider connections for features like connection pooling and load balancing, it requires the `provider_profile_id` to be available in **all** stream events - not just stream creation.

Without this information in events like `STREAM_STOPPED` or `CLIENT_CONNECTED`, m3u-editor cannot properly:
- Track active connections per provider profile
- Decrement connection counts when streams end
- Associate client connections with their originating provider profile

## Solution

This PR ensures the `metadata` field is included in all relevant stream events:

### Events Updated

| Event Type | File | Description |
|------------|------|-------------|
| `STREAM_STARTED` | `api.py` | Direct stream creation |
| `STREAM_STARTED` | `api.py` | Transcoded stream creation |
| `STREAM_STARTED` | `stream_manager.py` | Direct proxy mode start |
| `STREAM_STOPPED` | `api.py` | Manual deletion via API |
| `STREAM_STOPPED` | `api.py` | Metadata filter deletion (oldest) |
| `STREAM_STOPPED` | `api.py` | Metadata filter deletion (bulk) |
| `STREAM_STOPPED` | `stream_manager.py` | Normal stream completion |
| `STREAM_STOPPED` | `stream_manager.py` | Inactive timeout cleanup |
| `CLIENT_CONNECTED` | `api.py` | HLS playlist request |
| `CLIENT_CONNECTED` | `stream_manager.py` | Client registration |
| `CLIENT_DISCONNECTED` | `stream_manager.py` | Client disconnect |

### Example Event Payload (Before)
```json
{
  "event_type": "STREAM_STOPPED",
  "stream_id": "abc123",
  "data": {
    "reason": "manual_deletion",
    "was_transcoded": false
  }
}
```

### Example Event Payload (After)
```json
{
  "event_type": "STREAM_STOPPED",
  "stream_id": "abc123",
  "data": {
    "reason": "manual_deletion",
    "was_transcoded": false,
    "metadata": {
      "provider_profile_id": 5,
      "playlist_id": 1
    }
  }
}
```

## Use Case: Provider Profile Connection Tracking

With this change, m3u-editor can implement connection tracking per provider profile:

1. **STREAM_STARTED** → Increment `active_connections` for `provider_profile_id`
2. **CLIENT_CONNECTED** → Track client association with provider profile
3. **STREAM_STOPPED** → Decrement `active_connections` for `provider_profile_id`
4. **CLIENT_DISCONNECTED** → Update client tracking

This enables features like:
- Connection pooling across multiple provider profiles
- Load balancing based on active connections
- Accurate connection limit enforcement
- Real-time connection status in the UI

## Files Changed

- `src/api.py` - Added metadata to 6 event emissions
- `src/stream_manager.py` - Added metadata to 5 event emissions

## Testing

- Verified metadata is correctly passed through from stream creation to all lifecycle events
- Confirmed backward compatibility (metadata defaults to empty object `{}` if not provided)
- No breaking changes to existing webhook consumers

## Related

This change works in conjunction with the provider profile tracking feature in m3u-editor, which uses webhooks to maintain accurate connection counts per provider profile.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author