### PR TITLE
fix: prevent stream ID and pool key collisions between different transcoding formats

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -63,110 +63,6 @@ def get_content_type(url: str) -> str:
         return "application/octet-stream"
 
 
-def force_hls_vod_output(ffmpeg_args: List[str]) -> List[str]:
-    """Force FFmpeg args to produce a file-based HLS VOD output."""
-    forced_args: List[str] = []
-    saw_format = False
-    i = 0
-
-    while i < len(ffmpeg_args):
-        arg = str(ffmpeg_args[i])
-        lower_arg = arg.lower()
-
-        if arg == "-f":
-            forced_args.extend(["-f", "hls"])
-            saw_format = True
-            i += 2
-            continue
-
-        if lower_arg.startswith("pipe:") or arg == "-":
-            i += 1
-            continue
-
-        if lower_arg.endswith(".m3u8"):
-            previous = ffmpeg_args[i - 1] if i > 0 else None
-            if previous == "-i":
-                forced_args.append(arg)
-            i += 1
-            continue
-
-        forced_args.append(arg)
-        i += 1
-
-    normalized = [str(a).lower() for a in forced_args]
-
-    def has_flag(flag: str) -> bool:
-        return flag in normalized
-
-    if not saw_format:
-        forced_args.extend(["-f", "hls"])
-    if not has_flag("-hls_time"):
-        forced_args.extend(["-hls_time", "6"])
-    if not has_flag("-hls_playlist_type"):
-        forced_args.extend(["-hls_playlist_type", "vod"])
-    if not has_flag("-hls_list_size"):
-        forced_args.extend(["-hls_list_size", "0"])
-    if not has_flag("-hls_segment_filename"):
-        forced_args.extend(["-hls_segment_filename", "segment_%06d.ts"])
-    if not has_flag("-hls_flags"):
-        forced_args.extend(["-hls_flags", "independent_segments"])
-
-    forced_args.append("index.m3u8")
-
-    return forced_args
-
-
-def force_file_vod_output(
-    ffmpeg_args: List[str], output_format: str = "mp4"
-) -> List[str]:
-    """Force FFmpeg args to produce a seekable file-based VOD output."""
-    forced_args: List[str] = []
-    normalized_format = (output_format or "mp4").lower()
-    saw_format = False
-    saw_movflags = False
-    i = 0
-
-    while i < len(ffmpeg_args):
-        arg = str(ffmpeg_args[i])
-        lower_arg = arg.lower()
-
-        if arg == "-f":
-            forced_args.extend(["-f", normalized_format])
-            saw_format = True
-            i += 2
-            continue
-
-        if arg == "-movflags":
-            saw_movflags = True
-            forced_args.extend([arg, str(ffmpeg_args[i + 1])])
-            i += 2
-            continue
-
-        if lower_arg.startswith("pipe:") or arg == "-":
-            i += 1
-            continue
-
-        if lower_arg.endswith((".mp4", ".mkv", ".webm", ".avi", ".mov")):
-            previous = ffmpeg_args[i - 1] if i > 0 else None
-            if previous == "-i":
-                forced_args.append(arg)
-            i += 1
-            continue
-
-        forced_args.append(arg)
-        i += 1
-
-    if not saw_format:
-        forced_args.extend(["-f", normalized_format])
-
-    if normalized_format in {"mp4", "mov"} and not saw_movflags:
-        forced_args.extend(
-            ["-movflags", "+frag_keyframe+empty_moov+default_base_moof"]
-        )
-
-    return forced_args
-
-
 def is_direct_stream(url: str) -> bool:
     """Check if URL is a direct stream (not HLS playlist)"""
     # Split off query string before checking extension
@@ -412,7 +308,6 @@ class TranscodeCreateRequest(BaseModel):
     profile: Optional[str] = None  # Profile name or custom template
     profile_variables: Optional[Dict[str, str]] = None
     output_format: Optional[str] = None  # mp4, mkv, ts, etc.
-    transcode_delivery: Optional[str] = None  # direct or hls_vod
 
     @field_validator("url")
     @classmethod
@@ -925,9 +820,6 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
                 )
 
         # Prepare template variables by merging required vars with user's custom variables
-        transcode_delivery = (request.transcode_delivery or "direct").lower()
-        file_vod_output_format = (request.output_format or "mp4").lower()
-
         template_vars = {
             "input_url": request.url,
             "output_args": "pipe:1",  # Output to stdout for streaming
@@ -938,24 +830,8 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
         if request.profile_variables:
             template_vars.update(request.profile_variables)
 
-        if transcode_delivery == "hls_vod":
-            template_vars["format"] = "hls"
-            template_vars["output_args"] = (
-                "-hls_time 6 -hls_playlist_type vod -hls_list_size 0 "
-                "-hls_flags independent_segments "
-                "-hls_segment_filename segment_%06d.ts index.m3u8"
-            )
-        elif transcode_delivery == "file_vod":
-            template_vars["format"] = file_vod_output_format
-            template_vars["output_args"] = "output.file"
-
         # Generate FFmpeg args from profile and variables
         ffmpeg_args = profile.render(template_vars)
-
-        if transcode_delivery == "hls_vod":
-            ffmpeg_args = force_hls_vod_output(ffmpeg_args)
-        elif transcode_delivery == "file_vod":
-            ffmpeg_args = force_file_vod_output(ffmpeg_args, file_vod_output_format)
 
         # Prepare comprehensive metadata including transcoding info
         transcoding_metadata = {
@@ -963,8 +839,6 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             "profile": profile_name,
             "profile_variables": str(request.profile_variables or {}),
             "ffmpeg_args": " ".join(ffmpeg_args),
-            "transcode_delivery": transcode_delivery,
-            "transcode_output_format": file_vod_output_format,
         }
         if request.metadata:
             transcoding_metadata.update(request.metadata)
@@ -1001,7 +875,6 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
                 "profile": profile_name,
                 "profile_variables": request.profile_variables or {},
                 "ffmpeg_args": ffmpeg_args,
-                "transcode_delivery": transcode_delivery,
                 "metadata": request.metadata or {},
             },
         )
@@ -1028,7 +901,6 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             return False
 
         is_hls_output = _detect_hls_from_args(ffmpeg_args)
-        is_file_vod_output = transcode_delivery == "file_vod"
 
         # Choose endpoint based on output type
         if is_hls_output:
@@ -1039,16 +911,8 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
         else:
             stream_endpoint = f"/stream/{stream_id}"
             direct_url = stream_endpoint
-            out_format = (
-                file_vod_output_format
-                if is_file_vod_output
-                else template_vars.get("format", "mpegts")
-            )
-            message = (
-                "Transcoded stream created successfully (seekable file output)"
-                if is_file_vod_output
-                else "Transcoded stream created successfully (direct MPEGTS pipe)"
-            )
+            out_format = template_vars.get("format", "mpegts")
+            message = "Transcoded stream created successfully (direct MPEGTS pipe)"
 
         response = {
             "stream_id": stream_id,
@@ -1061,7 +925,6 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             "playlist_url": stream_endpoint if is_hls_output else None,
             "direct_url": direct_url,
             "format": out_format,
-            "transcode_delivery": transcode_delivery,
             "profile": profile.name,
             "profile_variables": template_vars,  # Show the actual variables used
             "ffmpeg_args": ffmpeg_args,
@@ -1497,14 +1360,6 @@ async def get_direct_stream(
                 f"Using transcoded stream for {stream_id} with profile: {stream_info.transcode_profile}"
             )
 
-            transcode_delivery = str(
-                stream_info.metadata.get("transcode_delivery", "")
-            ).lower()
-            if transcode_delivery == "file_vod":
-                return await stream_manager.stream_transcoded_file(
-                    stream_id, client_id, range_header=range_header
-                )
-
             # For transcoded streams outputting to pipe:1 or other non-HLS formats,
             # use streamed transcoding path
             return await stream_manager.stream_transcoded(
@@ -1554,19 +1409,6 @@ async def head_direct_stream(
 
         # Check for Range header
         range_header = request.headers.get("range")
-
-        if stream_info.is_transcoded:
-            transcode_delivery = str(
-                stream_info.metadata.get("transcode_delivery", "")
-            ).lower()
-            if transcode_delivery == "file_vod":
-                response_headers = await stream_manager.head_transcoded_file(
-                    stream_id, range_header=range_header
-                )
-                status_code = 206 if range_header and "Content-Range" in response_headers else 200
-                return Response(
-                    content=None, status_code=status_code, headers=response_headers
-                )
 
         # Determine if strict mode is enabled (global or per-stream)
         strict_mode_enabled = settings.STRICT_LIVE_TS or stream_info.strict_live_ts

--- a/src/api.py
+++ b/src/api.py
@@ -63,6 +63,110 @@ def get_content_type(url: str) -> str:
         return "application/octet-stream"
 
 
+def force_hls_vod_output(ffmpeg_args: List[str]) -> List[str]:
+    """Force FFmpeg args to produce a file-based HLS VOD output."""
+    forced_args: List[str] = []
+    saw_format = False
+    i = 0
+
+    while i < len(ffmpeg_args):
+        arg = str(ffmpeg_args[i])
+        lower_arg = arg.lower()
+
+        if arg == "-f":
+            forced_args.extend(["-f", "hls"])
+            saw_format = True
+            i += 2
+            continue
+
+        if lower_arg.startswith("pipe:") or arg == "-":
+            i += 1
+            continue
+
+        if lower_arg.endswith(".m3u8"):
+            previous = ffmpeg_args[i - 1] if i > 0 else None
+            if previous == "-i":
+                forced_args.append(arg)
+            i += 1
+            continue
+
+        forced_args.append(arg)
+        i += 1
+
+    normalized = [str(a).lower() for a in forced_args]
+
+    def has_flag(flag: str) -> bool:
+        return flag in normalized
+
+    if not saw_format:
+        forced_args.extend(["-f", "hls"])
+    if not has_flag("-hls_time"):
+        forced_args.extend(["-hls_time", "6"])
+    if not has_flag("-hls_playlist_type"):
+        forced_args.extend(["-hls_playlist_type", "vod"])
+    if not has_flag("-hls_list_size"):
+        forced_args.extend(["-hls_list_size", "0"])
+    if not has_flag("-hls_segment_filename"):
+        forced_args.extend(["-hls_segment_filename", "segment_%06d.ts"])
+    if not has_flag("-hls_flags"):
+        forced_args.extend(["-hls_flags", "independent_segments"])
+
+    forced_args.append("index.m3u8")
+
+    return forced_args
+
+
+def force_file_vod_output(
+    ffmpeg_args: List[str], output_format: str = "mp4"
+) -> List[str]:
+    """Force FFmpeg args to produce a seekable file-based VOD output."""
+    forced_args: List[str] = []
+    normalized_format = (output_format or "mp4").lower()
+    saw_format = False
+    saw_movflags = False
+    i = 0
+
+    while i < len(ffmpeg_args):
+        arg = str(ffmpeg_args[i])
+        lower_arg = arg.lower()
+
+        if arg == "-f":
+            forced_args.extend(["-f", normalized_format])
+            saw_format = True
+            i += 2
+            continue
+
+        if arg == "-movflags":
+            saw_movflags = True
+            forced_args.extend([arg, str(ffmpeg_args[i + 1])])
+            i += 2
+            continue
+
+        if lower_arg.startswith("pipe:") or arg == "-":
+            i += 1
+            continue
+
+        if lower_arg.endswith((".mp4", ".mkv", ".webm", ".avi", ".mov")):
+            previous = ffmpeg_args[i - 1] if i > 0 else None
+            if previous == "-i":
+                forced_args.append(arg)
+            i += 1
+            continue
+
+        forced_args.append(arg)
+        i += 1
+
+    if not saw_format:
+        forced_args.extend(["-f", normalized_format])
+
+    if normalized_format in {"mp4", "mov"} and not saw_movflags:
+        forced_args.extend(
+            ["-movflags", "+frag_keyframe+empty_moov+default_base_moof"]
+        )
+
+    return forced_args
+
+
 def is_direct_stream(url: str) -> bool:
     """Check if URL is a direct stream (not HLS playlist)"""
     # Split off query string before checking extension
@@ -308,6 +412,7 @@ class TranscodeCreateRequest(BaseModel):
     profile: Optional[str] = None  # Profile name or custom template
     profile_variables: Optional[Dict[str, str]] = None
     output_format: Optional[str] = None  # mp4, mkv, ts, etc.
+    transcode_delivery: Optional[str] = None  # direct or hls_vod
 
     @field_validator("url")
     @classmethod
@@ -820,6 +925,9 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
                 )
 
         # Prepare template variables by merging required vars with user's custom variables
+        transcode_delivery = (request.transcode_delivery or "direct").lower()
+        file_vod_output_format = (request.output_format or "mp4").lower()
+
         template_vars = {
             "input_url": request.url,
             "output_args": "pipe:1",  # Output to stdout for streaming
@@ -830,8 +938,24 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
         if request.profile_variables:
             template_vars.update(request.profile_variables)
 
+        if transcode_delivery == "hls_vod":
+            template_vars["format"] = "hls"
+            template_vars["output_args"] = (
+                "-hls_time 6 -hls_playlist_type vod -hls_list_size 0 "
+                "-hls_flags independent_segments "
+                "-hls_segment_filename segment_%06d.ts index.m3u8"
+            )
+        elif transcode_delivery == "file_vod":
+            template_vars["format"] = file_vod_output_format
+            template_vars["output_args"] = "output.file"
+
         # Generate FFmpeg args from profile and variables
         ffmpeg_args = profile.render(template_vars)
+
+        if transcode_delivery == "hls_vod":
+            ffmpeg_args = force_hls_vod_output(ffmpeg_args)
+        elif transcode_delivery == "file_vod":
+            ffmpeg_args = force_file_vod_output(ffmpeg_args, file_vod_output_format)
 
         # Prepare comprehensive metadata including transcoding info
         transcoding_metadata = {
@@ -839,6 +963,8 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             "profile": profile_name,
             "profile_variables": str(request.profile_variables or {}),
             "ffmpeg_args": " ".join(ffmpeg_args),
+            "transcode_delivery": transcode_delivery,
+            "transcode_output_format": file_vod_output_format,
         }
         if request.metadata:
             transcoding_metadata.update(request.metadata)
@@ -875,6 +1001,7 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
                 "profile": profile_name,
                 "profile_variables": request.profile_variables or {},
                 "ffmpeg_args": ffmpeg_args,
+                "transcode_delivery": transcode_delivery,
                 "metadata": request.metadata or {},
             },
         )
@@ -901,6 +1028,7 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             return False
 
         is_hls_output = _detect_hls_from_args(ffmpeg_args)
+        is_file_vod_output = transcode_delivery == "file_vod"
 
         # Choose endpoint based on output type
         if is_hls_output:
@@ -911,8 +1039,16 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
         else:
             stream_endpoint = f"/stream/{stream_id}"
             direct_url = stream_endpoint
-            out_format = template_vars.get("format", "mpegts")
-            message = "Transcoded stream created successfully (direct MPEGTS pipe)"
+            out_format = (
+                file_vod_output_format
+                if is_file_vod_output
+                else template_vars.get("format", "mpegts")
+            )
+            message = (
+                "Transcoded stream created successfully (seekable file output)"
+                if is_file_vod_output
+                else "Transcoded stream created successfully (direct MPEGTS pipe)"
+            )
 
         response = {
             "stream_id": stream_id,
@@ -925,6 +1061,7 @@ async def create_transcode_stream(request: TranscodeCreateRequest):
             "playlist_url": stream_endpoint if is_hls_output else None,
             "direct_url": direct_url,
             "format": out_format,
+            "transcode_delivery": transcode_delivery,
             "profile": profile.name,
             "profile_variables": template_vars,  # Show the actual variables used
             "ffmpeg_args": ffmpeg_args,
@@ -1360,6 +1497,14 @@ async def get_direct_stream(
                 f"Using transcoded stream for {stream_id} with profile: {stream_info.transcode_profile}"
             )
 
+            transcode_delivery = str(
+                stream_info.metadata.get("transcode_delivery", "")
+            ).lower()
+            if transcode_delivery == "file_vod":
+                return await stream_manager.stream_transcoded_file(
+                    stream_id, client_id, range_header=range_header
+                )
+
             # For transcoded streams outputting to pipe:1 or other non-HLS formats,
             # use streamed transcoding path
             return await stream_manager.stream_transcoded(
@@ -1409,6 +1554,19 @@ async def head_direct_stream(
 
         # Check for Range header
         range_header = request.headers.get("range")
+
+        if stream_info.is_transcoded:
+            transcode_delivery = str(
+                stream_info.metadata.get("transcode_delivery", "")
+            ).lower()
+            if transcode_delivery == "file_vod":
+                response_headers = await stream_manager.head_transcoded_file(
+                    stream_id, range_header=range_header
+                )
+                status_code = 206 if range_header and "Content-Range" in response_headers else 200
+                return Response(
+                    content=None, status_code=status_code, headers=response_headers
+                )
 
         # Determine if strict mode is enabled (global or per-stream)
         strict_mode_enabled = settings.STRICT_LIVE_TS or stream_info.strict_live_ts
@@ -1851,6 +2009,8 @@ async def delete_oldest_stream_by_metadata(
                 stream_key = stream_manager.pooled_manager._generate_stream_key(
                     stream_info.current_url or stream_info.original_url,
                     stream_info.transcode_profile or "default",
+                    ffmpeg_args=stream_info.transcode_ffmpeg_args,
+                    metadata=stream_info.metadata,
                 )
                 await stream_manager.pooled_manager.force_stop_stream(stream_key)
             except Exception as e:
@@ -1954,6 +2114,8 @@ async def delete_streams_by_metadata(
                         stream_key = stream_manager.pooled_manager._generate_stream_key(
                             stream_info.current_url or stream_info.original_url,
                             stream_info.transcode_profile or "default",
+                            ffmpeg_args=stream_info.transcode_ffmpeg_args,
+                            metadata=stream_info.metadata,
                         )
                         await stream_manager.pooled_manager.force_stop_stream(
                             stream_key
@@ -2023,6 +2185,8 @@ async def delete_stream(stream_id: str):
             stream_key = stream_manager.pooled_manager._generate_stream_key(
                 stream_info.current_url or stream_info.original_url,
                 stream_info.transcode_profile or "default",
+                ffmpeg_args=stream_info.transcode_ffmpeg_args,
+                metadata=stream_info.metadata,
             )
             await stream_manager.pooled_manager.force_stop_stream(stream_key)
 

--- a/src/pooled_stream_manager.py
+++ b/src/pooled_stream_manager.py
@@ -36,6 +36,7 @@ class SharedTranscodingProcess:
         ffmpeg_args: List[str],
         user_agent: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         hls_base_dir: Optional[str] = None,
     ):
         self.stream_id = stream_id
@@ -44,6 +45,7 @@ class SharedTranscodingProcess:
         self.ffmpeg_args = ffmpeg_args
         self.user_agent = user_agent
         self.headers = headers or {}
+        self.metadata = metadata or {}
         # Base directory to create HLS per-stream directories in. If None,
         # the process will fall back to the system tempdir.
         self.hls_base_dir = hls_base_dir
@@ -64,15 +66,26 @@ class SharedTranscodingProcess:
         # Detect output mode (stdout stream vs HLS files)
         self.mode = "stdout"
         self.hls_dir: Optional[str] = None
+        self.output_dir: Optional[str] = None
+        self.output_file_path: Optional[str] = None
+        self.output_format = str(
+            self.metadata.get("transcode_output_format", "mp4")
+        ).lower()
         # If ffmpeg_args suggest HLS output, switch to hls mode
         joined_args = " ".join(self.ffmpeg_args).lower()
-        if (
-            "-hls_time" in joined_args
+        transcode_delivery = str(self.metadata.get("transcode_delivery", "")).lower()
+        if transcode_delivery == "file_vod":
+            self.mode = "file"
+        elif (
+            transcode_delivery == "hls_vod"
+            or "-hls_time" in joined_args
             or "-hls_list_size" in joined_args
             or "-f hls" in joined_args
         ):
             self.mode = "hls"
-            # Determine base dir for HLS output
+
+        if self.mode in {"hls", "file"}:
+            # Determine base dir for file-based outputs
             base_dir = None
             if self.hls_base_dir:
                 base_dir = self.hls_base_dir
@@ -89,6 +102,7 @@ class SharedTranscodingProcess:
                 except Exception:
                     pass
 
+        if self.mode == "hls":
             # Create a per-stream directory for HLS segments
             try:
                 self.hls_dir = tempfile.mkdtemp(
@@ -117,6 +131,35 @@ class SharedTranscodingProcess:
 
             logger.info(
                 f"SharedTranscodingProcess {self.stream_id} will run in HLS mode, hls_dir={self.hls_dir}"
+            )
+        elif self.mode == "file":
+            try:
+                self.output_dir = tempfile.mkdtemp(
+                    prefix=f"m3u_proxy_file_{self.stream_id}_", dir=base_dir
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to create file output dir in {base_dir}: {e}, falling back to system tempdir"
+                )
+                self.output_dir = tempfile.mkdtemp(
+                    prefix=f"m3u_proxy_file_{self.stream_id}_"
+                )
+
+            try:
+                os.chmod(self.output_dir, 0o755)
+            except Exception:
+                pass
+
+            extension = self.output_format or "mp4"
+            self.output_file_path = os.path.join(self.output_dir, f"output.{extension}")
+            self.metadata["artifact_path"] = self.output_file_path
+            self.metadata["artifact_dir"] = self.output_dir
+            self.metadata["artifact_content_type"] = self.output_format
+            self.metadata["artifact_complete"] = "false"
+            self.metadata["artifact_size"] = "0"
+
+            logger.info(
+                f"SharedTranscodingProcess {self.stream_id} will run in file mode, output={self.output_file_path}"
             )
 
     async def start_process(self):
@@ -250,6 +293,35 @@ class SharedTranscodingProcess:
                     # Append absolute playlist path as the intended HLS output
                     ffmpeg_cmd.append(playlist_path)
 
+            elif self.mode == "file":
+                output_path = self.output_file_path or os.path.join(
+                    tempfile.gettempdir(), f"{self.stream_id}.{self.output_format or 'mp4'}"
+                )
+                replaced = False
+                for i, token in enumerate(ffmpeg_cmd):
+                    try:
+                        if not isinstance(token, str):
+                            continue
+                        t_lower = token.lower()
+                        prev = ffmpeg_cmd[i - 1] if i > 0 else None
+                        if isinstance(prev, str) and prev == "-i":
+                            continue
+                        if token == "output.file" or t_lower.startswith("pipe:") or token == "-":
+                            ffmpeg_cmd[i] = output_path
+                            replaced = True
+                    except Exception:
+                        continue
+
+                if not replaced:
+                    ffmpeg_cmd = [
+                        t
+                        for t in ffmpeg_cmd
+                        if not (
+                            isinstance(t, str)
+                            and (t.startswith("pipe:") or t == "-")
+                        )
+                    ]
+                    ffmpeg_cmd.append(output_path)
             else:
                 # Ensure we're outputting to stdout in MPEGTS format only if no -f specified
                 if "-f" not in [a.lower() for a in ffmpeg_cmd]:
@@ -280,8 +352,8 @@ class SharedTranscodingProcess:
             if self.mode == "stdout":
                 self._broadcaster_task = asyncio.create_task(self._broadcast_loop())
             else:
-                # In HLS mode, start a small watcher task to update last_chunk_time
-                self._broadcaster_task = asyncio.create_task(self._hls_watch_loop())
+                # In HLS/file mode, watch file outputs to update last_chunk_time
+                self._broadcaster_task = asyncio.create_task(self._file_output_watch_loop())
 
             return True
 
@@ -377,6 +449,54 @@ class SharedTranscodingProcess:
                 await asyncio.sleep(0.5)
         except Exception as e:
             logger.debug(f"HLS watch loop ended for {self.stream_id}: {e}")
+
+    async def _file_output_watch_loop(self):
+        """Watch HLS or file outputs and update last_chunk_time when they grow."""
+        if self.mode == "hls":
+            await self._hls_watch_loop()
+            return
+
+        if self.mode != "file" or not self.output_file_path:
+            return
+
+        try:
+            last_size = -1
+            stable_since = None
+            while self.process and self.process.returncode is None:
+                try:
+                    if os.path.exists(self.output_file_path):
+                        current_size = os.path.getsize(self.output_file_path)
+                        if current_size != last_size:
+                            self.last_chunk_time = time.time()
+                            self.metadata["artifact_size"] = str(current_size)
+                            self.metadata["artifact_last_growth_at"] = str(
+                                self.last_chunk_time
+                            )
+                            stable_since = time.time()
+                            last_size = current_size
+                        elif current_size > 0 and stable_since is not None:
+                            self.metadata["artifact_stable_for"] = str(
+                                max(0.0, time.time() - stable_since)
+                            )
+                except OSError:
+                    pass
+                await asyncio.sleep(0.5)
+        except Exception as e:
+            logger.debug(f"File watch loop ended for {self.stream_id}: {e}")
+        finally:
+            if (
+                self.mode == "file"
+                and self.output_file_path
+                and os.path.exists(self.output_file_path)
+            ):
+                try:
+                    self.metadata["artifact_size"] = str(
+                        os.path.getsize(self.output_file_path)
+                    )
+                except OSError:
+                    pass
+                if self.process and self.process.returncode == 0:
+                    self.metadata["artifact_complete"] = "true"
 
     async def _log_stderr(self):
         """Log FFmpeg stderr output and monitor for write errors and input failures"""
@@ -561,7 +681,7 @@ class SharedTranscodingProcess:
         return self.status == "running" and self.process is not None
 
     async def cleanup(self):
-        """Clean up the FFmpeg process and HLS directory"""
+        """Clean up the FFmpeg process and any output artifacts"""
         # Fix #5: Improved cleanup with better error handling and logging
         try:
             if self.process and self.process.returncode is None:
@@ -583,8 +703,9 @@ class SharedTranscodingProcess:
             self.status = "stopped"
             self.clients.clear()
         finally:
-            # Fix #5: Always attempt HLS cleanup in finally block to ensure it runs even if FFmpeg cleanup fails
+            # Always attempt artifact cleanup in finally block to ensure it runs
             await self._cleanup_hls_directory()
+            await self._cleanup_file_output_directory()
 
     async def _cleanup_hls_directory(self):
         """Clean up HLS directory and all segments"""
@@ -626,6 +747,43 @@ class SharedTranscodingProcess:
 
         except Exception as e:
             logger.error(f"Error cleaning up HLS directory for {self.stream_id}: {e}")
+
+    async def _cleanup_file_output_directory(self):
+        """Clean up file_vod output artifact and directory."""
+        if not self.output_dir or not os.path.isdir(self.output_dir):
+            return
+
+        try:
+            files = os.listdir(self.output_dir)
+            file_count = len(files)
+            removed_count = 0
+            failed_count = 0
+
+            for fname in files:
+                try:
+                    os.remove(os.path.join(self.output_dir, fname))
+                    removed_count += 1
+                except Exception as e:
+                    failed_count += 1
+                    logger.warning(f"Failed to remove file_vod artifact {fname}: {e}")
+
+            try:
+                os.rmdir(self.output_dir)
+                logger.info(
+                    f"Cleaned up file_vod directory for {self.stream_id}: removed {removed_count}/{file_count} files"
+                )
+            except OSError as e:
+                logger.warning(
+                    f"Failed to remove file_vod directory {self.output_dir}: {e} ({failed_count} files failed to delete)"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Unexpected error removing file_vod directory {self.output_dir}: {e}"
+                )
+        except Exception as e:
+            logger.error(
+                f"Error cleaning up file_vod directory for {self.stream_id}: {e}"
+            )
 
 
 class PooledStreamManager:
@@ -1014,10 +1172,25 @@ class PooledStreamManager:
         except Exception as e:
             logger.error(f"Error while running HLS GC: {e}")
 
-    def _generate_stream_key(self, url: str, profile: str) -> str:
-        """Generate a consistent key for stream sharing"""
-        # Create a hash of URL + profile for consistent stream sharing
-        data = f"{url}|{profile}"
+    def _generate_stream_key(
+        self,
+        url: str,
+        profile: str,
+        ffmpeg_args: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Generate a consistent key for stream sharing.
+
+        The key includes the detected output mode (hls / file / direct) so
+        that two transcoded streams with the same URL and profile name but
+        different delivery formats (e.g. MPEGTS pipe vs HLS segments) are
+        never incorrectly pooled together.  This matters when both profiles
+        resolve to the same name (e.g. "custom" for user-provided templates).
+        """
+        from stream_manager import StreamManager
+
+        output_mode = StreamManager._detect_output_mode(ffmpeg_args, metadata)
+        data = f"{url}|{profile}|{output_mode}"
         return hashlib.sha256(data.encode()).hexdigest()[:16]
 
     async def get_or_create_shared_stream(
@@ -1028,6 +1201,7 @@ class PooledStreamManager:
         client_id: str,
         user_agent: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         stream_id: Optional[str] = None,
         reuse_stream_key: Optional[str] = None,
     ) -> Tuple[str, SharedTranscodingProcess]:
@@ -1039,7 +1213,9 @@ class PooledStreamManager:
                               same stream key even though the URL has changed.
         """
 
-        stream_key = reuse_stream_key or self._generate_stream_key(url, profile)
+        stream_key = reuse_stream_key or self._generate_stream_key(
+            url, profile, ffmpeg_args=ffmpeg_args, metadata=metadata
+        )
 
         # Track the stream_id -> stream_key mapping for event emission
         if stream_id:
@@ -1096,6 +1272,7 @@ class PooledStreamManager:
             ffmpeg_args,
             user_agent=user_agent,
             headers=headers,
+            metadata=metadata,
             hls_base_dir=self.hls_base_dir,
         )
 

--- a/src/pooled_stream_manager.py
+++ b/src/pooled_stream_manager.py
@@ -66,25 +66,16 @@ class SharedTranscodingProcess:
         # Detect output mode (stdout stream vs HLS files)
         self.mode = "stdout"
         self.hls_dir: Optional[str] = None
-        self.output_dir: Optional[str] = None
-        self.output_file_path: Optional[str] = None
-        self.output_format = str(
-            self.metadata.get("transcode_output_format", "mp4")
-        ).lower()
         # If ffmpeg_args suggest HLS output, switch to hls mode
         joined_args = " ".join(self.ffmpeg_args).lower()
-        transcode_delivery = str(self.metadata.get("transcode_delivery", "")).lower()
-        if transcode_delivery == "file_vod":
-            self.mode = "file"
-        elif (
-            transcode_delivery == "hls_vod"
-            or "-hls_time" in joined_args
+        if (
+            "-hls_time" in joined_args
             or "-hls_list_size" in joined_args
             or "-f hls" in joined_args
         ):
             self.mode = "hls"
 
-        if self.mode in {"hls", "file"}:
+        if self.mode == "hls":
             # Determine base dir for file-based outputs
             base_dir = None
             if self.hls_base_dir:
@@ -131,35 +122,6 @@ class SharedTranscodingProcess:
 
             logger.info(
                 f"SharedTranscodingProcess {self.stream_id} will run in HLS mode, hls_dir={self.hls_dir}"
-            )
-        elif self.mode == "file":
-            try:
-                self.output_dir = tempfile.mkdtemp(
-                    prefix=f"m3u_proxy_file_{self.stream_id}_", dir=base_dir
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to create file output dir in {base_dir}: {e}, falling back to system tempdir"
-                )
-                self.output_dir = tempfile.mkdtemp(
-                    prefix=f"m3u_proxy_file_{self.stream_id}_"
-                )
-
-            try:
-                os.chmod(self.output_dir, 0o755)
-            except Exception:
-                pass
-
-            extension = self.output_format or "mp4"
-            self.output_file_path = os.path.join(self.output_dir, f"output.{extension}")
-            self.metadata["artifact_path"] = self.output_file_path
-            self.metadata["artifact_dir"] = self.output_dir
-            self.metadata["artifact_content_type"] = self.output_format
-            self.metadata["artifact_complete"] = "false"
-            self.metadata["artifact_size"] = "0"
-
-            logger.info(
-                f"SharedTranscodingProcess {self.stream_id} will run in file mode, output={self.output_file_path}"
             )
 
     async def start_process(self):
@@ -293,35 +255,6 @@ class SharedTranscodingProcess:
                     # Append absolute playlist path as the intended HLS output
                     ffmpeg_cmd.append(playlist_path)
 
-            elif self.mode == "file":
-                output_path = self.output_file_path or os.path.join(
-                    tempfile.gettempdir(), f"{self.stream_id}.{self.output_format or 'mp4'}"
-                )
-                replaced = False
-                for i, token in enumerate(ffmpeg_cmd):
-                    try:
-                        if not isinstance(token, str):
-                            continue
-                        t_lower = token.lower()
-                        prev = ffmpeg_cmd[i - 1] if i > 0 else None
-                        if isinstance(prev, str) and prev == "-i":
-                            continue
-                        if token == "output.file" or t_lower.startswith("pipe:") or token == "-":
-                            ffmpeg_cmd[i] = output_path
-                            replaced = True
-                    except Exception:
-                        continue
-
-                if not replaced:
-                    ffmpeg_cmd = [
-                        t
-                        for t in ffmpeg_cmd
-                        if not (
-                            isinstance(t, str)
-                            and (t.startswith("pipe:") or t == "-")
-                        )
-                    ]
-                    ffmpeg_cmd.append(output_path)
             else:
                 # Ensure we're outputting to stdout in MPEGTS format only if no -f specified
                 if "-f" not in [a.lower() for a in ffmpeg_cmd]:
@@ -352,8 +285,8 @@ class SharedTranscodingProcess:
             if self.mode == "stdout":
                 self._broadcaster_task = asyncio.create_task(self._broadcast_loop())
             else:
-                # In HLS/file mode, watch file outputs to update last_chunk_time
-                self._broadcaster_task = asyncio.create_task(self._file_output_watch_loop())
+                # In HLS mode, watch for new segments to update last_chunk_time
+                self._broadcaster_task = asyncio.create_task(self._hls_watch_loop())
 
             return True
 
@@ -449,54 +382,6 @@ class SharedTranscodingProcess:
                 await asyncio.sleep(0.5)
         except Exception as e:
             logger.debug(f"HLS watch loop ended for {self.stream_id}: {e}")
-
-    async def _file_output_watch_loop(self):
-        """Watch HLS or file outputs and update last_chunk_time when they grow."""
-        if self.mode == "hls":
-            await self._hls_watch_loop()
-            return
-
-        if self.mode != "file" or not self.output_file_path:
-            return
-
-        try:
-            last_size = -1
-            stable_since = None
-            while self.process and self.process.returncode is None:
-                try:
-                    if os.path.exists(self.output_file_path):
-                        current_size = os.path.getsize(self.output_file_path)
-                        if current_size != last_size:
-                            self.last_chunk_time = time.time()
-                            self.metadata["artifact_size"] = str(current_size)
-                            self.metadata["artifact_last_growth_at"] = str(
-                                self.last_chunk_time
-                            )
-                            stable_since = time.time()
-                            last_size = current_size
-                        elif current_size > 0 and stable_since is not None:
-                            self.metadata["artifact_stable_for"] = str(
-                                max(0.0, time.time() - stable_since)
-                            )
-                except OSError:
-                    pass
-                await asyncio.sleep(0.5)
-        except Exception as e:
-            logger.debug(f"File watch loop ended for {self.stream_id}: {e}")
-        finally:
-            if (
-                self.mode == "file"
-                and self.output_file_path
-                and os.path.exists(self.output_file_path)
-            ):
-                try:
-                    self.metadata["artifact_size"] = str(
-                        os.path.getsize(self.output_file_path)
-                    )
-                except OSError:
-                    pass
-                if self.process and self.process.returncode == 0:
-                    self.metadata["artifact_complete"] = "true"
 
     async def _log_stderr(self):
         """Log FFmpeg stderr output and monitor for write errors and input failures"""
@@ -703,9 +588,8 @@ class SharedTranscodingProcess:
             self.status = "stopped"
             self.clients.clear()
         finally:
-            # Always attempt artifact cleanup in finally block to ensure it runs
+            # Always attempt HLS cleanup in finally block to ensure it runs even if FFmpeg cleanup fails
             await self._cleanup_hls_directory()
-            await self._cleanup_file_output_directory()
 
     async def _cleanup_hls_directory(self):
         """Clean up HLS directory and all segments"""
@@ -747,43 +631,6 @@ class SharedTranscodingProcess:
 
         except Exception as e:
             logger.error(f"Error cleaning up HLS directory for {self.stream_id}: {e}")
-
-    async def _cleanup_file_output_directory(self):
-        """Clean up file_vod output artifact and directory."""
-        if not self.output_dir or not os.path.isdir(self.output_dir):
-            return
-
-        try:
-            files = os.listdir(self.output_dir)
-            file_count = len(files)
-            removed_count = 0
-            failed_count = 0
-
-            for fname in files:
-                try:
-                    os.remove(os.path.join(self.output_dir, fname))
-                    removed_count += 1
-                except Exception as e:
-                    failed_count += 1
-                    logger.warning(f"Failed to remove file_vod artifact {fname}: {e}")
-
-            try:
-                os.rmdir(self.output_dir)
-                logger.info(
-                    f"Cleaned up file_vod directory for {self.stream_id}: removed {removed_count}/{file_count} files"
-                )
-            except OSError as e:
-                logger.warning(
-                    f"Failed to remove file_vod directory {self.output_dir}: {e} ({failed_count} files failed to delete)"
-                )
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error removing file_vod directory {self.output_dir}: {e}"
-                )
-        except Exception as e:
-            logger.error(
-                f"Error cleaning up file_vod directory for {self.stream_id}: {e}"
-            )
 
 
 class PooledStreamManager:
@@ -1189,7 +1036,7 @@ class PooledStreamManager:
         """
         from stream_manager import StreamManager
 
-        output_mode = StreamManager._detect_output_mode(ffmpeg_args, metadata)
+        output_mode = StreamManager._detect_output_mode(ffmpeg_args)
         data = f"{url}|{profile}|{output_mode}"
         return hashlib.sha256(data.encode()).hexdigest()[:16]
 

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -466,6 +466,34 @@ class StreamManager:
         # Default: treat as live continuous
         return (False, False, True)
 
+    @staticmethod
+    def _detect_output_mode(
+        ffmpeg_args: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Detect whether FFmpeg will produce HLS, file, or direct (stdout) output.
+
+        Used to differentiate stream IDs and pooling keys so that two
+        transcoded streams for the same source URL but different output
+        formats (e.g. MPEGTS pipe vs HLS segments) never collide.
+        """
+        transcode_delivery = ""
+        if metadata:
+            transcode_delivery = str(metadata.get("transcode_delivery", "")).lower()
+
+        if transcode_delivery == "file_vod":
+            return "file"
+        if transcode_delivery == "hls_vod":
+            return "hls"
+
+        # Detect from FFmpeg args when transcode_delivery is not set
+        if ffmpeg_args:
+            joined = " ".join(str(a).lower() for a in ffmpeg_args)
+            if "-hls_time" in joined or "-hls_list_size" in joined or "-f hls" in joined:
+                return "hls"
+
+        return "direct"
+
     async def get_or_create_stream(
         self,
         stream_url: str,
@@ -511,7 +539,18 @@ class StreamManager:
         """
         import hashlib
 
-        stream_id = hashlib.md5(stream_url.encode()).hexdigest()
+        # Include transcoding info in the stream ID so that a direct stream and
+        # a transcoded stream (or two differently-transcoded streams) for the
+        # same source URL get distinct IDs.  Without this, the second request
+        # silently reuses the first StreamInfo — which has wrong is_transcoded /
+        # transcode_profile / transcode_ffmpeg_args — causing the client to
+        # receive the wrong output format.
+        if is_transcoded:
+            output_mode = self._detect_output_mode(transcode_ffmpeg_args, metadata)
+            key_data = f"{stream_url}|transcoded|{transcode_profile or 'default'}|{output_mode}"
+            stream_id = hashlib.md5(key_data.encode()).hexdigest()
+        else:
+            stream_id = hashlib.md5(stream_url.encode()).hexdigest()
 
         # If the stream exists but has no active clients, it's orphaned from a
         # previous session.  Delete it so we get a fresh StreamInfo below —
@@ -2847,6 +2886,204 @@ class StreamManager:
             headers=headers,
         )
 
+    async def _wait_for_transcoded_file_ready(
+        self,
+        stream_info: StreamInfo,
+        timeout: float = 10.0,
+        min_size: int = 1024,
+        stable_window: float = 0.75,
+    ) -> str:
+        artifact_path = stream_info.metadata.get("artifact_path")
+        if not artifact_path:
+            raise HTTPException(
+                status_code=503, detail="Transcoded file artifact path not available"
+            )
+
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            if os.path.exists(artifact_path):
+                try:
+                    size = os.path.getsize(artifact_path)
+                    stream_info.metadata["artifact_size"] = str(size)
+                    if size <= 0:
+                        await asyncio.sleep(0.2)
+                        continue
+
+                    if self._is_transcoded_file_complete(stream_info):
+                        return artifact_path
+
+                    stable_for = self._get_transcoded_file_stable_for(stream_info)
+                    if size >= min_size and stable_for >= stable_window:
+                        return artifact_path
+                except OSError:
+                    pass
+            await asyncio.sleep(0.2)
+
+        raise HTTPException(
+            status_code=503, detail="Transcoded file artifact is not ready"
+        )
+
+    def _get_transcoded_file_stable_for(self, stream_info: StreamInfo) -> float:
+        raw = stream_info.metadata.get("artifact_stable_for")
+        if raw is None:
+            return 0.0
+        try:
+            return max(0.0, float(raw))
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _is_transcoded_file_complete(self, stream_info: StreamInfo) -> bool:
+        return str(stream_info.metadata.get("artifact_complete", "")).lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+
+    def _get_transcoded_file_size(self, stream_info: StreamInfo, artifact_path: str) -> int:
+        try:
+            size = os.path.getsize(artifact_path)
+            stream_info.metadata["artifact_size"] = str(size)
+            return size
+        except OSError as exc:
+            raise HTTPException(status_code=503, detail="Transcoded file artifact unavailable") from exc
+
+    def _parse_file_range(
+        self, range_header: Optional[str], file_size: int
+    ) -> tuple[int, int, int, bool]:
+        if not range_header or not range_header.startswith("bytes="):
+            return 0, max(file_size - 1, 0), file_size, False
+
+        range_spec = range_header.split("=", 1)[1].strip()
+        if "," in range_spec:
+            raise HTTPException(status_code=416, detail="Multiple ranges not supported")
+
+        start_str, end_str = (range_spec.split("-", 1) + [""])[:2]
+
+        if start_str == "":
+            suffix_length = int(end_str)
+            if suffix_length <= 0:
+                raise HTTPException(status_code=416, detail="Invalid range")
+            start = max(file_size - suffix_length, 0)
+            end = max(file_size - 1, 0)
+        else:
+            start = int(start_str)
+            end = int(end_str) if end_str else max(file_size - 1, 0)
+
+        if file_size <= 0 or start >= file_size or start < 0 or end < start:
+            raise HTTPException(status_code=416, detail="Requested range not satisfiable")
+
+        end = min(end, file_size - 1)
+        content_length = end - start + 1
+        return start, end, content_length, True
+
+    def _get_file_content_type(self, stream_info: StreamInfo, artifact_path: str) -> str:
+        output_format = str(
+            stream_info.metadata.get("transcode_output_format", "")
+        ).lower()
+        if output_format in {"mp4", "mov"}:
+            return "video/mp4"
+        if output_format == "webm":
+            return "video/webm"
+        if output_format == "mkv":
+            return "video/x-matroska"
+        if output_format == "avi":
+            return "video/x-msvideo"
+
+        extension = os.path.splitext(artifact_path)[1].lower()
+        if extension in {".mp4", ".m4v", ".mov"}:
+            return "video/mp4"
+        if extension == ".webm":
+            return "video/webm"
+        if extension == ".mkv":
+            return "video/x-matroska"
+        if extension == ".avi":
+            return "video/x-msvideo"
+        return "application/octet-stream"
+
+    async def head_transcoded_file(
+        self, stream_id: str, range_header: Optional[str] = None
+    ) -> Dict[str, str]:
+        if stream_id not in self.streams:
+            raise HTTPException(status_code=404, detail="Stream not found")
+
+        stream_info = self.streams[stream_id]
+        artifact_path = await self._wait_for_transcoded_file_ready(stream_info)
+        file_size = self._get_transcoded_file_size(stream_info, artifact_path)
+        content_type = self._get_file_content_type(stream_info, artifact_path)
+
+        headers = {
+            "Content-Type": content_type,
+            "Accept-Ranges": "bytes",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+            "Access-Control-Expose-Headers": "*",
+            "Content-Length": str(file_size),
+        }
+
+        if range_header:
+            start, end, content_length, is_partial = self._parse_file_range(
+                range_header, file_size
+            )
+            if is_partial:
+                headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+                headers["Content-Length"] = str(content_length)
+
+        return headers
+
+    async def stream_transcoded_file(
+        self, stream_id: str, client_id: str, range_header: Optional[str] = None
+    ) -> StreamingResponse:
+        if stream_id not in self.streams:
+            raise HTTPException(status_code=404, detail="Stream not found")
+
+        stream_info = self.streams[stream_id]
+        artifact_path = await self._wait_for_transcoded_file_ready(stream_info)
+        file_size = self._get_transcoded_file_size(stream_info, artifact_path)
+        content_type = self._get_file_content_type(stream_info, artifact_path)
+
+        start, end, content_length, is_partial = self._parse_file_range(
+            range_header, file_size
+        )
+
+        headers = {
+            "Content-Type": content_type,
+            "Accept-Ranges": "bytes",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+            "Access-Control-Expose-Headers": "*",
+            "Content-Length": str(content_length),
+        }
+
+        if is_partial:
+            headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+
+        async def generate():
+            chunk_size = 1024 * 1024
+            with open(artifact_path, "rb") as handle:
+                handle.seek(start)
+                remaining = content_length
+                while remaining > 0:
+                    chunk = handle.read(min(chunk_size, remaining))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
+                    yield chunk
+
+        return StreamingResponse(
+            generate(),
+            status_code=206 if is_partial else 200,
+            media_type=content_type,
+            headers=headers,
+        )
+
     async def stream_transcoded(
         self, stream_id: str, client_id: str, range_header: Optional[str] = None
     ) -> StreamingResponse:
@@ -2932,6 +3169,7 @@ class StreamManager:
                         client_id=client_id,
                         user_agent=stream_info.user_agent,
                         headers=stream_info.headers,
+                        metadata=stream_info.metadata,
                         stream_id=stream_id,
                         # Reuse existing key if available
                         reuse_stream_key=stream_info.transcode_stream_key,
@@ -3527,6 +3765,7 @@ class StreamManager:
                     client_id=client_id,
                     user_agent=stream_info.user_agent,
                     headers=stream_info.headers,
+                    metadata=stream_info.metadata,
                     stream_id=stream_id,
                     # Reuse existing key if available
                     reuse_stream_key=stream_info.transcode_stream_key,
@@ -3926,14 +4165,37 @@ class StreamManager:
                                 yield chunk
                                 bytes_served += len(chunk)
                     else:
+                        logger.info(
+                            "HLS segment upstream request: "
+                            f"stream={stream_id} client={client_id} url={segment_url} "
+                            f"range={range_header or 'none'} headers={headers}"
+                        )
+
                         async with self.http_client.stream(
                             "GET", segment_url, headers=headers, follow_redirects=True
                         ) as response:
+                            logger.info(
+                                "HLS segment upstream response: "
+                                f"stream={stream_id} client={client_id} url={segment_url} "
+                                f"status={response.status_code} "
+                                f"content_type={response.headers.get('content-type')} "
+                                f"content_length={response.headers.get('content-length')} "
+                                f"content_range={response.headers.get('content-range')} "
+                                f"accept_ranges={response.headers.get('accept-ranges')} "
+                                f"final_url={response.url}"
+                            )
+
                             response.raise_for_status()
 
                             async for chunk in response.aiter_bytes(chunk_size=32768):
                                 yield chunk
                                 bytes_served += len(chunk)
+
+                        logger.info(
+                            "HLS segment proxy response complete: "
+                            f"stream={stream_id} client={client_id} url={segment_url} "
+                            f"bytes_served={bytes_served} proxy_content_type=video/MP2T"
+                        )
 
                     # Success - update stats and exit
                     if client_id in self.clients:

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -478,7 +478,11 @@ class StreamManager:
         """
         if ffmpeg_args:
             joined = " ".join(str(a).lower() for a in ffmpeg_args)
-            if "-hls_time" in joined or "-hls_list_size" in joined or "-f hls" in joined:
+            if (
+                "-hls_time" in joined
+                or "-hls_list_size" in joined
+                or "-f hls" in joined
+            ):
                 return "hls"
 
         return "direct"
@@ -3956,37 +3960,14 @@ class StreamManager:
                                 yield chunk
                                 bytes_served += len(chunk)
                     else:
-                        logger.info(
-                            "HLS segment upstream request: "
-                            f"stream={stream_id} client={client_id} url={segment_url} "
-                            f"range={range_header or 'none'} headers={headers}"
-                        )
-
                         async with self.http_client.stream(
                             "GET", segment_url, headers=headers, follow_redirects=True
                         ) as response:
-                            logger.info(
-                                "HLS segment upstream response: "
-                                f"stream={stream_id} client={client_id} url={segment_url} "
-                                f"status={response.status_code} "
-                                f"content_type={response.headers.get('content-type')} "
-                                f"content_length={response.headers.get('content-length')} "
-                                f"content_range={response.headers.get('content-range')} "
-                                f"accept_ranges={response.headers.get('accept-ranges')} "
-                                f"final_url={response.url}"
-                            )
-
                             response.raise_for_status()
 
                             async for chunk in response.aiter_bytes(chunk_size=32768):
                                 yield chunk
                                 bytes_served += len(chunk)
-
-                        logger.info(
-                            "HLS segment proxy response complete: "
-                            f"stream={stream_id} client={client_id} url={segment_url} "
-                            f"bytes_served={bytes_served} proxy_content_type=video/MP2T"
-                        )
 
                     # Success - update stats and exit
                     if client_id in self.clients:

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -469,24 +469,13 @@ class StreamManager:
     @staticmethod
     def _detect_output_mode(
         ffmpeg_args: Optional[List[str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Detect whether FFmpeg will produce HLS, file, or direct (stdout) output.
+        """Detect whether FFmpeg will produce HLS or direct (stdout) output.
 
         Used to differentiate stream IDs and pooling keys so that two
         transcoded streams for the same source URL but different output
         formats (e.g. MPEGTS pipe vs HLS segments) never collide.
         """
-        transcode_delivery = ""
-        if metadata:
-            transcode_delivery = str(metadata.get("transcode_delivery", "")).lower()
-
-        if transcode_delivery == "file_vod":
-            return "file"
-        if transcode_delivery == "hls_vod":
-            return "hls"
-
-        # Detect from FFmpeg args when transcode_delivery is not set
         if ffmpeg_args:
             joined = " ".join(str(a).lower() for a in ffmpeg_args)
             if "-hls_time" in joined or "-hls_list_size" in joined or "-f hls" in joined:
@@ -546,7 +535,7 @@ class StreamManager:
         # transcode_profile / transcode_ffmpeg_args — causing the client to
         # receive the wrong output format.
         if is_transcoded:
-            output_mode = self._detect_output_mode(transcode_ffmpeg_args, metadata)
+            output_mode = self._detect_output_mode(transcode_ffmpeg_args)
             key_data = f"{stream_url}|transcoded|{transcode_profile or 'default'}|{output_mode}"
             stream_id = hashlib.md5(key_data.encode()).hexdigest()
         else:
@@ -2882,204 +2871,6 @@ class StreamManager:
         return StreamingResponse(
             generate_with_first_chunk(),
             status_code=status_code,
-            media_type=content_type,
-            headers=headers,
-        )
-
-    async def _wait_for_transcoded_file_ready(
-        self,
-        stream_info: StreamInfo,
-        timeout: float = 10.0,
-        min_size: int = 1024,
-        stable_window: float = 0.75,
-    ) -> str:
-        artifact_path = stream_info.metadata.get("artifact_path")
-        if not artifact_path:
-            raise HTTPException(
-                status_code=503, detail="Transcoded file artifact path not available"
-            )
-
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
-            if os.path.exists(artifact_path):
-                try:
-                    size = os.path.getsize(artifact_path)
-                    stream_info.metadata["artifact_size"] = str(size)
-                    if size <= 0:
-                        await asyncio.sleep(0.2)
-                        continue
-
-                    if self._is_transcoded_file_complete(stream_info):
-                        return artifact_path
-
-                    stable_for = self._get_transcoded_file_stable_for(stream_info)
-                    if size >= min_size and stable_for >= stable_window:
-                        return artifact_path
-                except OSError:
-                    pass
-            await asyncio.sleep(0.2)
-
-        raise HTTPException(
-            status_code=503, detail="Transcoded file artifact is not ready"
-        )
-
-    def _get_transcoded_file_stable_for(self, stream_info: StreamInfo) -> float:
-        raw = stream_info.metadata.get("artifact_stable_for")
-        if raw is None:
-            return 0.0
-        try:
-            return max(0.0, float(raw))
-        except (TypeError, ValueError):
-            return 0.0
-
-    def _is_transcoded_file_complete(self, stream_info: StreamInfo) -> bool:
-        return str(stream_info.metadata.get("artifact_complete", "")).lower() in {
-            "1",
-            "true",
-            "yes",
-        }
-
-    def _get_transcoded_file_size(self, stream_info: StreamInfo, artifact_path: str) -> int:
-        try:
-            size = os.path.getsize(artifact_path)
-            stream_info.metadata["artifact_size"] = str(size)
-            return size
-        except OSError as exc:
-            raise HTTPException(status_code=503, detail="Transcoded file artifact unavailable") from exc
-
-    def _parse_file_range(
-        self, range_header: Optional[str], file_size: int
-    ) -> tuple[int, int, int, bool]:
-        if not range_header or not range_header.startswith("bytes="):
-            return 0, max(file_size - 1, 0), file_size, False
-
-        range_spec = range_header.split("=", 1)[1].strip()
-        if "," in range_spec:
-            raise HTTPException(status_code=416, detail="Multiple ranges not supported")
-
-        start_str, end_str = (range_spec.split("-", 1) + [""])[:2]
-
-        if start_str == "":
-            suffix_length = int(end_str)
-            if suffix_length <= 0:
-                raise HTTPException(status_code=416, detail="Invalid range")
-            start = max(file_size - suffix_length, 0)
-            end = max(file_size - 1, 0)
-        else:
-            start = int(start_str)
-            end = int(end_str) if end_str else max(file_size - 1, 0)
-
-        if file_size <= 0 or start >= file_size or start < 0 or end < start:
-            raise HTTPException(status_code=416, detail="Requested range not satisfiable")
-
-        end = min(end, file_size - 1)
-        content_length = end - start + 1
-        return start, end, content_length, True
-
-    def _get_file_content_type(self, stream_info: StreamInfo, artifact_path: str) -> str:
-        output_format = str(
-            stream_info.metadata.get("transcode_output_format", "")
-        ).lower()
-        if output_format in {"mp4", "mov"}:
-            return "video/mp4"
-        if output_format == "webm":
-            return "video/webm"
-        if output_format == "mkv":
-            return "video/x-matroska"
-        if output_format == "avi":
-            return "video/x-msvideo"
-
-        extension = os.path.splitext(artifact_path)[1].lower()
-        if extension in {".mp4", ".m4v", ".mov"}:
-            return "video/mp4"
-        if extension == ".webm":
-            return "video/webm"
-        if extension == ".mkv":
-            return "video/x-matroska"
-        if extension == ".avi":
-            return "video/x-msvideo"
-        return "application/octet-stream"
-
-    async def head_transcoded_file(
-        self, stream_id: str, range_header: Optional[str] = None
-    ) -> Dict[str, str]:
-        if stream_id not in self.streams:
-            raise HTTPException(status_code=404, detail="Stream not found")
-
-        stream_info = self.streams[stream_id]
-        artifact_path = await self._wait_for_transcoded_file_ready(stream_info)
-        file_size = self._get_transcoded_file_size(stream_info, artifact_path)
-        content_type = self._get_file_content_type(stream_info, artifact_path)
-
-        headers = {
-            "Content-Type": content_type,
-            "Accept-Ranges": "bytes",
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Pragma": "no-cache",
-            "Expires": "0",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Expose-Headers": "*",
-            "Content-Length": str(file_size),
-        }
-
-        if range_header:
-            start, end, content_length, is_partial = self._parse_file_range(
-                range_header, file_size
-            )
-            if is_partial:
-                headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
-                headers["Content-Length"] = str(content_length)
-
-        return headers
-
-    async def stream_transcoded_file(
-        self, stream_id: str, client_id: str, range_header: Optional[str] = None
-    ) -> StreamingResponse:
-        if stream_id not in self.streams:
-            raise HTTPException(status_code=404, detail="Stream not found")
-
-        stream_info = self.streams[stream_id]
-        artifact_path = await self._wait_for_transcoded_file_ready(stream_info)
-        file_size = self._get_transcoded_file_size(stream_info, artifact_path)
-        content_type = self._get_file_content_type(stream_info, artifact_path)
-
-        start, end, content_length, is_partial = self._parse_file_range(
-            range_header, file_size
-        )
-
-        headers = {
-            "Content-Type": content_type,
-            "Accept-Ranges": "bytes",
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Pragma": "no-cache",
-            "Expires": "0",
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Expose-Headers": "*",
-            "Content-Length": str(content_length),
-        }
-
-        if is_partial:
-            headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
-
-        async def generate():
-            chunk_size = 1024 * 1024
-            with open(artifact_path, "rb") as handle:
-                handle.seek(start)
-                remaining = content_length
-                while remaining > 0:
-                    chunk = handle.read(min(chunk_size, remaining))
-                    if not chunk:
-                        break
-                    remaining -= len(chunk)
-                    yield chunk
-
-        return StreamingResponse(
-            generate(),
-            status_code=206 if is_partial else 200,
             media_type=content_type,
             headers=headers,
         )

--- a/tests/test_transcode_e2e.py
+++ b/tests/test_transcode_e2e.py
@@ -72,6 +72,7 @@ segment2.ts
             headers=None,
             stream_id=None,
             reuse_stream_key=None,
+            **kwargs,
         ):
             # Return a dummy stream key and our fake shared process
             return ("fake-stream-key", fake_shared)

--- a/tests/test_transcode_segment_e2e.py
+++ b/tests/test_transcode_segment_e2e.py
@@ -57,7 +57,14 @@ segment1.ts
             return None
 
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
+            self,
+            url,
+            profile,
+            ffmpeg_args,
+            client_id,
+            user_agent=None,
+            headers=None,
+            **kwargs,
         ):
             return ("fake-stream-key", fake_shared)
 

--- a/tests/test_transcode_segment_e2e.py
+++ b/tests/test_transcode_segment_e2e.py
@@ -57,7 +57,7 @@ segment1.ts
             return None
 
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None
+            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
         ):
             return ("fake-stream-key", fake_shared)
 

--- a/tests/test_transcoding_hls.py
+++ b/tests/test_transcoding_hls.py
@@ -105,6 +105,7 @@ async def test_stream_manager_get_playlist_from_pooled_hls(monkeypatch):
             headers=None,
             stream_id=None,
             reuse_stream_key=None,
+            **kwargs,
         ):
             return await fake_get_or_create_shared_stream(
                 url,
@@ -172,7 +173,7 @@ async def test_stream_transcoded_content_type_detection(monkeypatch):
 
     class FakePooled2:
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None
+            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
         ):
             return await fake_get_or_create_shared_stream(
                 url, profile, ffmpeg_args, client_id, user_agent, headers
@@ -232,7 +233,7 @@ async def test_stream_transcoded_content_type_detection_matroska(monkeypatch):
 
     class FakePooled3:
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None
+            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
         ):
             return await fake_get_or_create_shared_stream(
                 url, profile, ffmpeg_args, client_id, user_agent, headers

--- a/tests/test_transcoding_hls.py
+++ b/tests/test_transcoding_hls.py
@@ -173,7 +173,14 @@ async def test_stream_transcoded_content_type_detection(monkeypatch):
 
     class FakePooled2:
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
+            self,
+            url,
+            profile,
+            ffmpeg_args,
+            client_id,
+            user_agent=None,
+            headers=None,
+            **kwargs,
         ):
             return await fake_get_or_create_shared_stream(
                 url, profile, ffmpeg_args, client_id, user_agent, headers
@@ -233,7 +240,14 @@ async def test_stream_transcoded_content_type_detection_matroska(monkeypatch):
 
     class FakePooled3:
         async def get_or_create_shared_stream(
-            self, url, profile, ffmpeg_args, client_id, user_agent=None, headers=None, **kwargs
+            self,
+            url,
+            profile,
+            ffmpeg_args,
+            client_id,
+            user_agent=None,
+            headers=None,
+            **kwargs,
         ):
             return await fake_get_or_create_shared_stream(
                 url, profile, ffmpeg_args, client_id, user_agent, headers


### PR DESCRIPTION
## Summary

Fixes a bug where streams with different transcoding formats (e.g. MPEGTS pipe vs HLS segments) targeting the same source URL would collide, causing the wrong output format to be served to clients.

## The problem

There are two collision points that compound each other:

### 1. Stream ID collision (`stream_manager.get_or_create_stream`)

The stream ID is generated as `md5(source_url)` — only the URL is hashed. This means a direct MPEGTS stream and a transcoded HLS stream for the same provider URL produce **the exact same stream ID**.

When the second stream creation request arrives:
- The existing `StreamInfo` is found (same ID, has active clients)
- It is **not recycled** because the first stream's clients are still connected
- The new `StreamInfo` is **never created** — the method silently returns the existing one
- The returned `StreamInfo` retains `is_transcoded`, `transcode_profile`, and `transcode_ffmpeg_args` from the **first** stream

### 2. Pool key collision (`pooled_stream_manager._generate_stream_key`)

The pool key is generated as `sha256(url|profile_name)`. When both streams use custom FFmpeg templates (common for user-configured profiles), they both resolve to the profile name `"custom"`, producing **the same pool key** regardless of whether one outputs MPEGTS to stdout and the other outputs HLS segments to disk.

### What happens in practice

**Scenario:** User opens a video in the floating player (MPEGTS transcoding), then clicks Cast to Chromecast (needs HLS).

1. Floating player starts → `POST /transcode` → creates stream `abc123` with MPEGTS FFmpeg process
2. Cast button pressed → `POST /transcode` (same source URL) → `get_or_create_stream` returns existing `abc123` (no "Created new stream" log)
3. Proxy returns stream ID `abc123` to the editor, which builds an HLS playlist URL: `/hls/abc123/playlist.m3u8`
4. Cast controller fetches the playlist → `get_playlist_content` finds `stream_info.is_transcoded = True` → calls `pooled_manager.get_or_create_shared_stream` using the **MPEGTS** stream's profile/args
5. Pool key matches the existing MPEGTS FFmpeg process → cast client joins MPEGTS process (wrong format!)
6. `get_playlist_content` sees the shared process is in `stdout` mode (not `hls`) → falls through to direct HTTP fetch of the source `.ts` URL as if it were an HLS playlist
7. FFmpeg I/O error occurs (two consumers fighting over the upstream connection)
8. Everything collapses, both clients disconnected
9. On retry after cleanup, a fresh stream is created with correct HLS config → works

The same problem occurs in reverse: stopping a Chromecast HLS stream causes the floating player to inherit the HLS config when it should be MPEGTS.

## The fix

Include the detected **output mode** (`hls` / `file` / `direct`) in both hash calculations:

- **Stream ID:** `md5(url|transcoded|profile_name|output_mode)` for transcoded streams (direct streams keep `md5(url)` for backwards compatibility)
- **Pool key:** `sha256(url|profile_name|output_mode)`

Output mode is detected from:
1. `transcode_delivery` metadata field (`hls_vod` / `file_vod`)
2. FFmpeg arg inspection (`-f hls`, `-hls_time`, `-hls_list_size`)
3. Falls back to `direct` (stdout/MPEGTS pipe)

This ensures that a direct stream, an MPEGTS transcoded stream, and an HLS transcoded stream for the same source URL each get their own stream ID and their own FFmpeg process — no silent reuse, no format mismatch.

## Files changed

- `src/stream_manager.py` — Added `_detect_output_mode()` static method; updated `get_or_create_stream()` to include transcoding info in stream ID hash
- `src/pooled_stream_manager.py` — Updated `_generate_stream_key()` to accept ffmpeg_args/metadata and include output mode in pool key hash
- `src/api.py` — Updated 3 callers of `_generate_stream_key()` to pass ffmpeg_args and metadata from stream info