### PR TITLE
feat: Preserve fMP4/CMAF segments in HLS pass-through

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1321,6 +1321,28 @@ async def get_hls_segment_ts(
     return await get_hls_segment(stream_id, request, client_id, url)
 
 
+@app.get("/hls/{stream_id}/segment.m4s")
+async def get_hls_segment_m4s(
+    stream_id: str,
+    request: Request,
+    client_id: str = Query(..., description="Client ID"),
+    url: str = Query(..., description="The segment URL to proxy"),
+):
+    """Proxy fMP4/CMAF HLS segment (used for HEVC and Apple AVKit playback)."""
+    return await get_hls_segment(stream_id, request, client_id, url)
+
+
+@app.get("/hls/{stream_id}/segment.mp4")
+async def get_hls_segment_mp4(
+    stream_id: str,
+    request: Request,
+    client_id: str = Query(..., description="Client ID"),
+    url: str = Query(..., description="The segment URL to proxy"),
+):
+    """Proxy fMP4 HLS init segment (EXT-X-MAP) or .mp4 segment file."""
+    return await get_hls_segment(stream_id, request, client_id, url)
+
+
 def _start_disconnect_monitor(
     request: Request, client_id: str, sm: StreamManager
 ) -> None:

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -167,38 +167,76 @@ class M3U8Processor:
                             media.absolute_uri, base_proxy_url
                         )
             else:
+                # Track init_section objects we've already rewritten — the same
+                # Initialization object is shared across all segments that follow
+                # an EXT-X-MAP declaration, so we must rewrite each one only once.
+                seen_init_sections = set()
                 for segment in playlist.segments:
                     segment.uri = self._rewrite_url(
                         segment.absolute_uri, base_proxy_url
                     )
-                # Handle initialization section if present
-                for seg_map in (
+                    init_section = getattr(segment, "init_section", None)
+                    if (
+                        init_section
+                        and getattr(init_section, "uri", None)
+                        and id(init_section) not in seen_init_sections
+                    ):
+                        init_section.uri = self._rewrite_url(
+                            init_section.absolute_uri, base_proxy_url
+                        )
+                        seen_init_sections.add(id(init_section))
+
+                # Handle playlist-level segment_map (some m3u8 lib versions expose
+                # the EXT-X-MAP entries here as a list). Skip objects already
+                # visited via segment.init_section above.
+                segment_maps = (
                     playlist.segment_map
                     if isinstance(playlist.segment_map, list)
-                    else []
-                ):
-                    if hasattr(seg_map, "uri") and seg_map.uri:
+                    else ([playlist.segment_map] if playlist.segment_map else [])
+                )
+                for seg_map in segment_maps:
+                    if (
+                        getattr(seg_map, "uri", None)
+                        and id(seg_map) not in seen_init_sections
+                    ):
                         seg_map.uri = self._rewrite_url(
                             seg_map.absolute_uri, base_proxy_url
                         )
+                        seen_init_sections.add(id(seg_map))
 
             return playlist.dumps()
         except Exception as e:
             logger.error(f"Error processing M3U8 playlist: {e}")
             return content
 
+    @staticmethod
+    def _segment_kind(url: str) -> str:
+        """Classify an HLS segment URL by its file extension.
+
+        Returns the routing extension used in proxy URLs ("ts", "m4s", or "mp4").
+        Defaults to "ts" for unknown extensions to preserve existing behavior.
+        """
+        path = url.split("?", 1)[0].lower()
+        if path.endswith((".m4s", ".cmfv", ".cmfa", ".cmft")):
+            return "m4s"
+        if path.endswith(".mp4"):
+            return "mp4"
+        return "ts"
+
     def _rewrite_url(self, original_url: str, base_proxy_url: str) -> str:
         """Rewrites a URL to point to the proxy, encoding the original URL."""
         encoded_url = quote(original_url, safe="")
         # Check path only — strip query params to handle URLs like *.m3u8?location=ABC123
-        if original_url.split("?")[0].endswith(".m3u8"):
+        path = original_url.split("?", 1)[0].lower()
+        if path.endswith(".m3u8"):
             # For variant playlists, include parent stream ID
             parent_param = (
                 f"&parent={self.parent_stream_id}" if self.parent_stream_id else ""
             )
             return f"{base_proxy_url}/playlist.m3u8?url={encoded_url}&client_id={self.client_id}{parent_param}"
-        else:
-            return f"{base_proxy_url}/segment.ts?url={encoded_url}&client_id={self.client_id}"
+
+        kind = self._segment_kind(original_url)
+        return f"{base_proxy_url}/segment.{kind}?url={encoded_url}&client_id={self.client_id}"
 
 
 class StreamManager:
@@ -3937,6 +3975,25 @@ class StreamManager:
                     )
                     return None
 
+    @staticmethod
+    def _segment_content_type(segment_url: str) -> str:
+        """Infer the response Content-Type for an HLS segment from its URL.
+
+        Defaults to MPEG-TS so existing .ts pass-through stays bit-exact.
+        fMP4/CMAF segments need their own MIME so strict players (e.g. Apple
+        AVKit on tvOS) can decode HEVC content carried in fragmented MP4.
+        """
+        path = segment_url.split("?", 1)[0].lower()
+        if path.endswith((".m4s", ".cmfv", ".cmfa", ".cmft")):
+            return "video/iso.segment"
+        if path.endswith(".mp4"):
+            return "video/mp4"
+        if path.endswith(".aac"):
+            return "audio/aac"
+        if path.endswith(".vtt"):
+            return "text/vtt"
+        return "video/mp2t"
+
     async def proxy_hls_segment(
         self,
         stream_id: str,
@@ -4050,9 +4107,10 @@ class StreamManager:
                     logger.error(f"Unexpected error streaming HLS segment: {e}")
                     raise
 
+        media_type = self._segment_content_type(segment_url)
         return StreamingResponse(
             segment_generator(),
-            media_type="video/MP2T",
+            media_type=media_type,
             headers={
                 "Cache-Control": "no-cache",
                 "Access-Control-Allow-Origin": "*",

--- a/tests/test_stream_manager.py
+++ b/tests/test_stream_manager.py
@@ -94,6 +94,178 @@ http://original.com/segment2.ts"""
         )
         assert expected_url2 in result
 
+    def test_segment_kind_classifier(self):
+        """Each known HLS segment extension routes to its dedicated proxy path."""
+        kind = M3U8Processor._segment_kind
+        assert kind("http://x/y/seg.ts") == "ts"
+        assert kind("http://x/y/seg.ts?token=abc") == "ts"
+        assert kind("http://x/y/seg.m4s") == "m4s"
+        assert kind("http://x/y/seg.m4s?Policy=signed&Signature=xyz") == "m4s"
+        assert kind("http://x/y/seg.cmfv") == "m4s"
+        assert kind("http://x/y/seg.cmfa") == "m4s"
+        assert kind("http://x/y/init.mp4") == "mp4"
+        assert kind("http://x/y/SEG.M4S") == "m4s"
+        assert kind("http://x/y/seg.unknown") == "ts"
+
+    def test_rewrite_fmp4_manifest_with_init_segment(self):
+        """fMP4 manifests must rewrite EXT-X-MAP and .m4s segments through the
+        kind-aware proxy routes so strict players (Apple AVKit on tvOS) see
+        the correct extensions and content types."""
+        from urllib.parse import quote
+
+        processor = M3U8Processor("http://original.com/", "stream123")
+
+        playlist = """#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.0,
+seg00001.m4s
+#EXTINF:6.0,
+seg00002.m4s
+#EXT-X-ENDLIST"""
+
+        proxy_base_url = "http://proxy.com/hls/stream123"
+        result = processor.process_playlist(
+            playlist, proxy_base_url, "http://original.com/"
+        )
+
+        encoded_init = quote("http://original.com/init.mp4", safe="")
+        assert (
+            f"{proxy_base_url}/segment.mp4?url={encoded_init}&client_id=stream123"
+            in result
+        )
+
+        encoded_seg1 = quote("http://original.com/seg00001.m4s", safe="")
+        assert (
+            f"{proxy_base_url}/segment.m4s?url={encoded_seg1}&client_id=stream123"
+            in result
+        )
+
+        encoded_seg2 = quote("http://original.com/seg00002.m4s", safe="")
+        assert (
+            f"{proxy_base_url}/segment.m4s?url={encoded_seg2}&client_id=stream123"
+            in result
+        )
+
+        assert "EXT-X-MAP" in result
+
+    def test_init_section_rewritten_only_once(self):
+        """A single EXT-X-MAP applies to all subsequent segments — its URI must
+        be rewritten exactly once. Re-rewriting would double-encode the proxy
+        URL into itself and break the init segment fetch."""
+        from urllib.parse import quote
+
+        processor = M3U8Processor("http://original.com/", "stream123")
+
+        playlist = """#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.0,
+seg1.m4s
+#EXTINF:6.0,
+seg2.m4s
+#EXTINF:6.0,
+seg3.m4s
+#EXT-X-ENDLIST"""
+
+        proxy_base_url = "http://proxy.com/hls/stream123"
+        result = processor.process_playlist(
+            playlist, proxy_base_url, "http://original.com/"
+        )
+
+        map_lines = [line for line in result.splitlines() if "EXT-X-MAP" in line]
+        assert len(map_lines) == 1
+        # Double-encoding would leave a percent-encoded "http%3A%2F%2Fproxy.com"
+        # nested inside the URL — that would mean we rewrote our own rewrite.
+        assert "http%3A%2F%2Fproxy.com" not in map_lines[0]
+        encoded_init = quote("http://original.com/init.mp4", safe="")
+        assert encoded_init in map_lines[0]
+
+    def test_ts_passthrough_uses_segment_ts_route(self):
+        """Regression: vanilla .ts manifests still route through /segment.ts so
+        existing players keep working unchanged."""
+        from urllib.parse import quote
+
+        processor = M3U8Processor("http://original.com/", "stream123")
+
+        playlist = """#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXTINF:10.0,
+http://original.com/seg1.ts
+#EXTINF:10.0,
+http://original.com/seg2.ts"""
+
+        proxy_base_url = "http://proxy.com/hls/stream123"
+        result = processor.process_playlist(
+            playlist, proxy_base_url, "http://original.com/"
+        )
+
+        encoded_seg1 = quote("http://original.com/seg1.ts", safe="")
+        assert (
+            f"{proxy_base_url}/segment.ts?url={encoded_seg1}&client_id=stream123"
+            in result
+        )
+        assert "/segment.m4s?" not in result
+        assert "/segment.mp4?" not in result
+
+
+class TestSegmentContentType:
+    """Test StreamManager._segment_content_type — used to set the response
+    Content-Type when proxying HLS segment bytes."""
+
+    def test_ts_returns_mpeg_ts(self):
+        assert StreamManager._segment_content_type("http://x/y/seg.ts") == "video/mp2t"
+        assert (
+            StreamManager._segment_content_type("http://x/y/seg.ts?token=abc")
+            == "video/mp2t"
+        )
+
+    def test_m4s_returns_iso_segment(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/seg.m4s")
+            == "video/iso.segment"
+        )
+        assert (
+            StreamManager._segment_content_type("http://x/y/seg.cmfv")
+            == "video/iso.segment"
+        )
+        assert (
+            StreamManager._segment_content_type("http://x/y/seg.cmfa")
+            == "video/iso.segment"
+        )
+
+    def test_mp4_returns_video_mp4(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/init.mp4") == "video/mp4"
+        )
+
+    def test_aac_returns_audio_aac(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/audio.aac") == "audio/aac"
+        )
+
+    def test_vtt_returns_text_vtt(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/captions.vtt") == "text/vtt"
+        )
+
+    def test_unknown_defaults_to_mpeg_ts(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/seg.xyz") == "video/mp2t"
+        )
+        assert StreamManager._segment_content_type("http://x/y/seg") == "video/mp2t"
+
+    def test_case_insensitive(self):
+        assert (
+            StreamManager._segment_content_type("http://x/y/SEG.M4S")
+            == "video/iso.segment"
+        )
+
 
 class TestStreamManager:
     """Test StreamManager functionality"""


### PR DESCRIPTION
## Summary

- HLS streams with fragmented MP4 (CMAF) segments now pass through the proxy with their original container intact
- Adds `/segment.m4s` and `/segment.mp4` route aliases alongside the existing `/segment.ts` so manifest URLs match their actual content
- Walks per-segment `EXT-X-MAP` init section URIs through the proxy as well, deduped so the shared init reference isn't double-encoded
- Replaces the hardcoded `video/MP2T` response Content-Type with one inferred from the segment URL extension; falls back to MPEG-TS for `.ts` and unknown types so existing `.ts` behaviour is bit-exact

## Why

Apple AVKit on tvOS (and other strict HLS clients) require fragmented MP4 segments to play HEVC/H.265 streams — HEVC over MPEG-TS isn't part of Apple's HLS spec. Previously the rewriter routed every segment URL through `/segment.ts` regardless of upstream container, and served everything as `video/MP2T`. Even when upstream provided clean fMP4, downstream players got a manifest contract mismatch and couldn't decode.

## What changed

- `src/stream_manager.py` — kind-aware `_rewrite_url`, per-segment `init_section` walk with id-based dedupe, static `_segment_content_type` helper used by `proxy_hls_segment`
- `src/api.py` — `/hls/{stream_id}/segment.m4s` and `/hls/{stream_id}/segment.mp4` route aliases (existing `/segment.ts` alias kept unchanged for back-compat)
- `tests/test_stream_manager.py` — 11 new pytest cases

## Test plan

- [x] New pytest cases cover segment-kind classification, fMP4 manifest rewriting (segments + EXT-X-MAP), init-section dedupe, content-type inference, and `.ts` regression
- [x] Full `tests/test_stream_manager.py` passes (27/27)
- [x] No regressions across `test_api.py`, `test_transcoding_hls.py`, `test_hls_cleanup.py`, `test_hls_gc.py` (38/38 total)
- [x] End-to-end verified live with an upstream fMP4 source — segment URLs correctly route through `/segment.mp4` (init) and `/segment.m4s` (media)
- [x] Profile-driven HLS-mode transcoding to fMP4 verified — ffmpeg outputs `init.mp4` + `*.m4s` segments, proxy serves them through the kind-aware routes

Pairs with m3ue/m3u-editor#1077, which adds a "Default HLS fMP4 Profile" preset for users who want fMP4 output via transcoding rather than passthrough.