### PR TITLE
fix: Stop treating ffmpeg's HLS segment-end EOF as an upstream failure

### DIFF
--- a/src/pooled_stream_manager.py
+++ b/src/pooled_stream_manager.py
@@ -45,6 +45,41 @@ _AUDIO_LAYOUT_RE = re.compile(
 # "1280x720" or "1920x1080 [SAR 1:1 DAR 16:9]" inside a Stream line.
 _RESOLUTION_RE = re.compile(r"\b(?P<w>\d{2,5})x(?P<h>\d{2,5})\b")
 
+# stderr substrings (case-insensitive match) that signal ffmpeg has been told
+# to write somewhere it can't. These mark the stream as failed for cleanup.
+_FFMPEG_WRITE_ERROR_PATTERNS = (
+    "no space left on device",
+    "permission denied",
+    "i/o error",
+    "disk full",
+    "cannot write",
+    "failed to open",
+    "error writing",
+)
+
+# stderr substrings (case-insensitive match) that signal a genuine upstream
+# input failure and should trip failover. We deliberately do NOT include the
+# bare "end of file" string: ffmpeg 8.1 writes "Error reading HTTP response:
+# End of file" on every HLS segment fetch end (the HTTP layer closes when the
+# segment body is exhausted) and immediately reconnects via -reconnect 1, so
+# that line is normal traffic — not a stream failure. Genuine upstream loss
+# is still caught by:
+#   * the more specific patterns below ("connection refused", "server returned
+#     4xx/5xx", "error opening input", etc. — emitted when reconnect fails)
+#   * the low-bitrate / silence detectors in stream_manager.py, which trigger
+#     on actual data starvation regardless of what stderr says.
+_FFMPEG_INPUT_ERROR_PATTERNS = (
+    "error opening input",
+    "failed to resolve hostname",
+    "connection refused",
+    "connection timed out",
+    "input/output error",
+    "server returned 4",  # Matches 403, 404, etc.
+    "server returned 5",  # Matches 500, 502, 503, etc.
+    "invalid data found",
+    "protocol not found",
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -576,31 +611,6 @@ class SharedTranscodingProcess:
             return
 
         try:
-            # Monitor FFmpeg stderr for various error conditions
-            write_error_patterns = [
-                "no space left on device",
-                "permission denied",
-                "i/o error",
-                "disk full",
-                "cannot write",
-                "failed to open",
-                "error writing",
-            ]
-
-            # Input/connection error patterns that should trigger failover
-            input_error_patterns = [
-                "error opening input",
-                "failed to resolve hostname",
-                "connection refused",
-                "connection timed out",
-                "input/output error",
-                "server returned 4",  # Matches 403, 404, etc.
-                "server returned 5",  # Matches 500, 502, 503, etc.
-                "invalid data found",
-                "protocol not found",
-                "end of file",
-            ]
-
             # Read stderr in small chunks and buffer lines ourselves to avoid
             # asyncio.StreamReader's LimitOverrunError when ffmpeg writes very
             # long lines without a newline (which results in the message
@@ -656,7 +666,7 @@ class SharedTranscodingProcess:
                     line_lower = line_str.lower()
 
                     # Check for write errors
-                    for pattern in write_error_patterns:
+                    for pattern in _FFMPEG_WRITE_ERROR_PATTERNS:
                         if pattern in line_lower:
                             logger.error(
                                 f"FFmpeg write error detected for {self.stream_id}: {line_str}"
@@ -666,7 +676,7 @@ class SharedTranscodingProcess:
                             break
 
                     # Check for input/connection errors that should trigger failover
-                    for pattern in input_error_patterns:
+                    for pattern in _FFMPEG_INPUT_ERROR_PATTERNS:
                         if pattern in line_lower:
                             logger.error(
                                 f"FFmpeg input error detected for {self.stream_id}: {line_str}"

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -452,7 +452,10 @@ class TestFFmpegErrorPatterns:
     """Test FFmpeg stderr error pattern detection"""
 
     def test_input_error_patterns(self):
-        """Test that SharedTranscodingProcess detects input errors"""
+        """Test that SharedTranscodingProcess detects input errors via the
+        module-level pattern tuple."""
+        from pooled_stream_manager import _FFMPEG_INPUT_ERROR_PATTERNS
+
         # These are the error patterns we should detect
         error_patterns = [
             "Error opening input file https://example.com/stream.m3u8",
@@ -465,21 +468,20 @@ class TestFFmpegErrorPatterns:
             "Protocol not found",
         ]
 
-        # Verify each pattern would be caught
         for error_msg in error_patterns:
             assert any(
-                pattern in error_msg.lower()
-                for pattern in [
-                    "error opening input",
-                    "failed to resolve hostname",
-                    "connection refused",
-                    "connection timed out",
-                    "server returned 4",
-                    "server returned 5",
-                    "invalid data found",
-                    "protocol not found",
-                ]
-            )
+                pattern in error_msg.lower() for pattern in _FFMPEG_INPUT_ERROR_PATTERNS
+            ), f"Expected to match an input error pattern: {error_msg}"
+
+    def test_input_error_patterns_excludes_bare_end_of_file(self):
+        """Regression: ffmpeg 8.1 prints 'Error reading HTTP response: End of file'
+        on every HLS segment fetch end while -reconnect 1 silently reconnects,
+        so 'end of file' must not be a failover trigger on its own. Real upstream
+        loss is caught by the more specific patterns + the data-starvation
+        detector in stream_manager."""
+        from pooled_stream_manager import _FFMPEG_INPUT_ERROR_PATTERNS
+
+        assert "end of file" not in _FFMPEG_INPUT_ERROR_PATTERNS
 
     @pytest.mark.asyncio
     async def test_stderr_monitor_detects_input_error(self):
@@ -510,6 +512,36 @@ class TestFFmpegErrorPatterns:
 
         # Should have marked the stream as input_failed
         assert process.status == "input_failed"
+
+    @pytest.mark.asyncio
+    async def test_stderr_monitor_ignores_segment_end_eof(self):
+        """Regression for ffmpeg 8.1: a normal HLS segment-fetch EOF must NOT
+        flip status to input_failed. ffmpeg 8.1 logs this on every segment end
+        and recovers via -reconnect 1, so it isn't a failure."""
+        process = SharedTranscodingProcess(
+            stream_id="test_stream_eof",
+            url="http://example.com/stream.m3u8",
+            profile="test",
+            ffmpeg_args=["-i", "{input_url}", "-c", "copy", "pipe:1"],
+            user_agent="test-agent",
+        )
+
+        mock_process = Mock()
+        mock_stderr = AsyncMock()
+
+        eof_line = (
+            b"[http @ 0x7f202400c740] Error reading HTTP response: End of file\n"
+        )
+        mock_stderr.read = AsyncMock(side_effect=[eof_line, b""])
+
+        mock_process.stderr = mock_stderr
+        mock_process.returncode = None
+        process.process = mock_process
+
+        await process._log_stderr()
+
+        # Status must remain "starting" (init default), not flip to input_failed.
+        assert process.status != "input_failed"
 
 
 class TestFailoverStats:


### PR DESCRIPTION
## Summary

`linuxserver/ffmpeg:latest` recently ticked from 8.0.1 to 8.1, and 8.1 surfaces a new stderr line on every HLS segment fetch end: `[http @ 0x...] Error reading HTTP response: End of file`. The HTTP layer just closes when the segment body is exhausted, and `-reconnect 1 -reconnect_streamed 1` silently reopens the connection for the next segment — i.e. it's normal traffic, not a failure.

But the existing `input_error_patterns` in `pooled_stream_manager.py` had a bare `"end of file"` entry, so this line started flipping `status = "input_failed"` once per HLS segment (~every 10 seconds), causing the streaming generator to trigger failover and the player to constantly reconnect. ffmpeg 8.0.1 didn't expose this log, which is why the issue only emerged with the latest base image.

## What changed

- Drop `"end of file"` from the input error patterns. Real upstream loss is still caught by:
  - the more specific patterns (`connection refused`, `server returned 4xx/5xx`, `error opening input`, `connection timed out`, `invalid data found`, etc. — emitted when ffmpeg's reconnect actually fails)
  - the low-bitrate / silence detectors in `stream_manager.py`, which trigger on actual data starvation regardless of stderr
- Lift the two pattern lists to module-level tuples (`_FFMPEG_WRITE_ERROR_PATTERNS`, `_FFMPEG_INPUT_ERROR_PATTERNS`) so they can be referenced from tests and don't get rebuilt per stderr-reader call

## Test plan

- [x] Existing failover tests pass (`tests/test_failover.py::TestFFmpegErrorPatterns`)
- [x] New regression test asserts a bare `[http @ ...] Error reading HTTP response: End of file` line on stderr does not flip status to `input_failed`
- [x] Verified live against ffmpeg 8.1 on an HLS source: no more 10-second flapping; failovers only occur when the upstream genuinely returns an HTTP error / closes the playlist refresh

## Compatibility

The patch is purely subtractive and has no public-API impact. Older ffmpeg versions that don't print this line are unaffected. The remaining patterns cover the same set of genuine input failures they always did.