### PR TITLE
feat: Expose output_media_info for transcoded streams

### DIFF
--- a/src/pooled_stream_manager.py
+++ b/src/pooled_stream_manager.py
@@ -45,6 +45,41 @@ _AUDIO_LAYOUT_RE = re.compile(
 # "1280x720" or "1920x1080 [SAR 1:1 DAR 16:9]" inside a Stream line.
 _RESOLUTION_RE = re.compile(r"\b(?P<w>\d{2,5})x(?P<h>\d{2,5})\b")
 
+# stderr substrings (case-insensitive match) that signal ffmpeg has been told
+# to write somewhere it can't. These mark the stream as failed for cleanup.
+_FFMPEG_WRITE_ERROR_PATTERNS = (
+    "no space left on device",
+    "permission denied",
+    "i/o error",
+    "disk full",
+    "cannot write",
+    "failed to open",
+    "error writing",
+)
+
+# stderr substrings (case-insensitive match) that signal a genuine upstream
+# input failure and should trip failover. We deliberately do NOT include the
+# bare "end of file" string: ffmpeg 8.1 writes "Error reading HTTP response:
+# End of file" on every HLS segment fetch end (the HTTP layer closes when the
+# segment body is exhausted) and immediately reconnects via -reconnect 1, so
+# that line is normal traffic — not a stream failure. Genuine upstream loss
+# is still caught by:
+#   * the more specific patterns below ("connection refused", "server returned
+#     4xx/5xx", "error opening input", etc. — emitted when reconnect fails)
+#   * the low-bitrate / silence detectors in stream_manager.py, which trigger
+#     on actual data starvation regardless of what stderr says.
+_FFMPEG_INPUT_ERROR_PATTERNS = (
+    "error opening input",
+    "failed to resolve hostname",
+    "connection refused",
+    "connection timed out",
+    "input/output error",
+    "server returned 4",  # Matches 403, 404, etc.
+    "server returned 5",  # Matches 500, 502, 503, etc.
+    "invalid data found",
+    "protocol not found",
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -576,31 +611,6 @@ class SharedTranscodingProcess:
             return
 
         try:
-            # Monitor FFmpeg stderr for various error conditions
-            write_error_patterns = [
-                "no space left on device",
-                "permission denied",
-                "i/o error",
-                "disk full",
-                "cannot write",
-                "failed to open",
-                "error writing",
-            ]
-
-            # Input/connection error patterns that should trigger failover
-            input_error_patterns = [
-                "error opening input",
-                "failed to resolve hostname",
-                "connection refused",
-                "connection timed out",
-                "input/output error",
-                "server returned 4",  # Matches 403, 404, etc.
-                "server returned 5",  # Matches 500, 502, 503, etc.
-                "invalid data found",
-                "protocol not found",
-                "end of file",
-            ]
-
             # Read stderr in small chunks and buffer lines ourselves to avoid
             # asyncio.StreamReader's LimitOverrunError when ffmpeg writes very
             # long lines without a newline (which results in the message
@@ -656,7 +666,7 @@ class SharedTranscodingProcess:
                     line_lower = line_str.lower()
 
                     # Check for write errors
-                    for pattern in write_error_patterns:
+                    for pattern in _FFMPEG_WRITE_ERROR_PATTERNS:
                         if pattern in line_lower:
                             logger.error(
                                 f"FFmpeg write error detected for {self.stream_id}: {line_str}"
@@ -666,7 +676,7 @@ class SharedTranscodingProcess:
                             break
 
                     # Check for input/connection errors that should trigger failover
-                    for pattern in input_error_patterns:
+                    for pattern in _FFMPEG_INPUT_ERROR_PATTERNS:
                         if pattern in line_lower:
                             logger.error(
                                 f"FFmpeg input error detected for {self.stream_id}: {line_str}"

--- a/src/pooled_stream_manager.py
+++ b/src/pooled_stream_manager.py
@@ -28,6 +28,13 @@ _FFMPEG_INPUT_LINE_RE = re.compile(
     r"^\s*Input #\d+,\s*(?P<container>[\w,]+),\s*from\s+"
 )
 
+# "Output #0, mpegts, to 'pipe:1':" or "Output #0, hls, to '/path/index.m3u8':".
+# Once this line is emitted by ffmpeg, every subsequent Stream # line refers to
+# the encoder/muxer output rather than the source input.
+_FFMPEG_OUTPUT_LINE_RE = re.compile(
+    r"^\s*Output #\d+,\s*(?P<container>[\w,]+),\s*to\s+"
+)
+
 # "Stream #0:0[0x100]: Video: h264 (Main) ([27][0][0][0] / 0x001B), yuv420p..."
 # "Stream #0:0[0x100][0x200]: Video: hevc ..." (dual PID bracket groups in MPEG-TS)
 # "Stream #0:1[0x101](eng): Audio: aac (LC) ..."
@@ -102,6 +109,15 @@ class SharedTranscodingProcess:
         # providers reject the second connection. Empty for resolver streams
         # (streamlink/yt-dlp) that don't go through ffmpeg.
         self.media_info: Dict[str, Any] = {}
+        # Output-side counterpart describing what ffmpeg is producing right now
+        # (encoder codec / target resolution / muxer container) plus the live
+        # progress fields, which are technically output stats. Populated only
+        # after ffmpeg prints its "Output #" line, so it stays empty for plain
+        # passthrough where no ffmpeg process is involved.
+        self.output_media_info: Dict[str, Any] = {}
+        # Parser state: flips True once "Output #" is seen in stderr so the
+        # Stream-line parser knows where to route subsequent codec lines.
+        self._parsing_output: bool = False
 
         # Broadcasting support - each client gets its own queue
         self.client_queues: Dict[str, asyncio.Queue] = {}
@@ -504,15 +520,34 @@ class SharedTranscodingProcess:
         if container and "container" not in self.media_info:
             self.media_info["container"] = container.upper()
 
+    def _parse_ffmpeg_output_line(self, line_str: str) -> None:
+        """
+        Parse ffmpeg's "Output #0, FORMAT, to 'TARGET':" line. Captures the
+        muxer container into output_media_info and flips the parser state so
+        that subsequent Stream # lines are recognised as output streams. Only
+        the first Output block is honoured — multi-output configs (e.g. tee)
+        would each restate the marker but we keep the first match.
+        """
+        match = _FFMPEG_OUTPUT_LINE_RE.match(line_str)
+        if not match:
+            return
+        self._parsing_output = True
+        container = match.group("container").strip().split(",")[0].strip()
+        if container and "container" not in self.output_media_info:
+            self.output_media_info["container"] = container.upper()
+
     def _parse_ffmpeg_stream_line(self, line_str: str) -> None:
         """
         Parse ffmpeg's "Stream #0:N[...]: Video|Audio: ..." lines for codec
         details. ffmpeg prints one per stream right after the input is opened
         — this is free metadata that doesn't require a second connection.
+        Routes into media_info or output_media_info based on whether the
+        "Output #" marker has been seen yet.
         """
         match = _FFMPEG_STREAM_LINE_RE.search(line_str)
         if not match:
             return
+        target = self.output_media_info if self._parsing_output else self.media_info
         stream_type = match.group("type").lower()
         details = match.group("details")
         if stream_type == "video":
@@ -520,55 +555,70 @@ class SharedTranscodingProcess:
             # profile (e.g. "h264 (Main) (HEVC / 0x...)" — strip parens).
             codec = details.split(",", 1)[0].strip()
             codec = re.sub(r"\s*\(.*", "", codec).strip()
-            if codec and "video_codec" not in self.media_info:
-                self.media_info["video_codec"] = codec
+            if codec and "video_codec" not in target:
+                target["video_codec"] = codec
             res_match = _RESOLUTION_RE.search(details)
-            if res_match and "resolution" not in self.media_info:
-                self.media_info["resolution"] = (
+            if res_match and "resolution" not in target:
+                target["resolution"] = (
                     f"{res_match.group('w')}x{res_match.group('h')}"
                 )
         elif stream_type == "audio":
             codec = details.split(",", 1)[0].strip()
             codec = re.sub(r"\s*\(.*", "", codec).strip()
-            if codec and "audio_codec" not in self.media_info:
-                self.media_info["audio_codec"] = codec
+            if codec and "audio_codec" not in target:
+                target["audio_codec"] = codec
             layout_match = _AUDIO_LAYOUT_RE.search(details)
-            if layout_match and "audio_channels" not in self.media_info:
-                self.media_info["audio_channels"] = layout_match.group("layout")
+            if layout_match and "audio_channels" not in target:
+                target["audio_channels"] = layout_match.group("layout")
 
     def _parse_ffmpeg_progress(self, line_str: str) -> None:
         """
         Extract live progress fields (bitrate, fps, frame, speed) from a single
-        ffmpeg stderr line and update media_info. No-op for non-progress lines.
+        ffmpeg stderr line. Progress numbers describe the encoder output, so
+        once the "Output #" marker has been seen we mirror them into
+        output_media_info. We also keep writing them to media_info so existing
+        callers (Stream Info badge row in m3u-editor PR #1089) don't regress.
+        No-op for non-progress lines.
         """
         # Cheap pre-filter — most stderr lines aren't progress
         if "bitrate=" not in line_str and "fps=" not in line_str:
             return
+        targets = [self.media_info]
+        if self._parsing_output:
+            targets.append(self.output_media_info)
         for match in _FFMPEG_PROGRESS_FIELD_RE.finditer(line_str):
             key = match.group("key")
             raw = match.group("val")
             if key == "bitrate":
                 if raw.endswith("kbits/s"):
                     try:
-                        self.media_info["bitrate_kbps"] = round(float(raw[:-7]), 1)
+                        value = round(float(raw[:-7]), 1)
                     except ValueError:
-                        pass
+                        continue
+                    for t in targets:
+                        t["bitrate_kbps"] = value
             elif key == "fps":
                 try:
-                    self.media_info["fps"] = round(float(raw), 2)
+                    value = round(float(raw), 2)
                 except ValueError:
-                    pass
+                    continue
+                for t in targets:
+                    t["fps"] = value
             elif key == "frame":
                 try:
-                    self.media_info["frame"] = int(raw)
+                    value = int(raw)
                 except ValueError:
-                    pass
+                    continue
+                for t in targets:
+                    t["frame"] = value
             elif key == "speed":
                 if raw.endswith("x"):
                     try:
-                        self.media_info["speed"] = round(float(raw[:-1]), 2)
+                        value = round(float(raw[:-1]), 2)
                     except ValueError:
-                        pass
+                        continue
+                    for t in targets:
+                        t["speed"] = value
 
     async def _log_stderr(self):
         """Log FFmpeg stderr output and monitor for write errors and input failures"""
@@ -650,6 +700,7 @@ class SharedTranscodingProcess:
                     # populate stale values.
                     if not self.resolver_type:
                         self._parse_ffmpeg_input_line(line_str)
+                        self._parse_ffmpeg_output_line(line_str)
                         self._parse_ffmpeg_stream_line(line_str)
                         self._parse_ffmpeg_progress(line_str)
 

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -4551,6 +4551,21 @@ class StreamManager:
             return {}
         return dict(getattr(process, "media_info", {}) or {})
 
+    def _get_output_media_info(self, stream: "StreamInfo") -> Dict[str, Any]:
+        """
+        Look up live encoder/muxer output info for a transcoded stream — the
+        codec/container/resolution ffmpeg has been told to produce, plus the
+        live progress fields that describe what's being written downstream.
+        Empty for non-transcoded streams (no ffmpeg process) or before ffmpeg
+        emits its "Output #" line.
+        """
+        if not stream.transcode_stream_key or not self.pooled_manager:
+            return {}
+        process = self.pooled_manager.shared_processes.get(stream.transcode_stream_key)
+        if not process:
+            return {}
+        return dict(getattr(process, "output_media_info", {}) or {})
+
     def get_stats(self) -> Dict:
         """Get comprehensive stats - aggregates variant stream stats into parent streams"""
         # Only count non-variant streams
@@ -4683,6 +4698,7 @@ class StreamManager:
                     "metadata": stream.metadata,
                     "headers": stream.headers,
                     "media_info": self._get_media_info(stream),
+                    "output_media_info": self._get_output_media_info(stream),
                 }
                 for stream in non_variant_streams
             ],

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -452,7 +452,10 @@ class TestFFmpegErrorPatterns:
     """Test FFmpeg stderr error pattern detection"""
 
     def test_input_error_patterns(self):
-        """Test that SharedTranscodingProcess detects input errors"""
+        """Test that SharedTranscodingProcess detects input errors via the
+        module-level pattern tuple."""
+        from pooled_stream_manager import _FFMPEG_INPUT_ERROR_PATTERNS
+
         # These are the error patterns we should detect
         error_patterns = [
             "Error opening input file https://example.com/stream.m3u8",
@@ -465,21 +468,20 @@ class TestFFmpegErrorPatterns:
             "Protocol not found",
         ]
 
-        # Verify each pattern would be caught
         for error_msg in error_patterns:
             assert any(
-                pattern in error_msg.lower()
-                for pattern in [
-                    "error opening input",
-                    "failed to resolve hostname",
-                    "connection refused",
-                    "connection timed out",
-                    "server returned 4",
-                    "server returned 5",
-                    "invalid data found",
-                    "protocol not found",
-                ]
-            )
+                pattern in error_msg.lower() for pattern in _FFMPEG_INPUT_ERROR_PATTERNS
+            ), f"Expected to match an input error pattern: {error_msg}"
+
+    def test_input_error_patterns_excludes_bare_end_of_file(self):
+        """Regression: ffmpeg 8.1 prints 'Error reading HTTP response: End of file'
+        on every HLS segment fetch end while -reconnect 1 silently reconnects,
+        so 'end of file' must not be a failover trigger on its own. Real upstream
+        loss is caught by the more specific patterns + the data-starvation
+        detector in stream_manager."""
+        from pooled_stream_manager import _FFMPEG_INPUT_ERROR_PATTERNS
+
+        assert "end of file" not in _FFMPEG_INPUT_ERROR_PATTERNS
 
     @pytest.mark.asyncio
     async def test_stderr_monitor_detects_input_error(self):
@@ -510,6 +512,36 @@ class TestFFmpegErrorPatterns:
 
         # Should have marked the stream as input_failed
         assert process.status == "input_failed"
+
+    @pytest.mark.asyncio
+    async def test_stderr_monitor_ignores_segment_end_eof(self):
+        """Regression for ffmpeg 8.1: a normal HLS segment-fetch EOF must NOT
+        flip status to input_failed. ffmpeg 8.1 logs this on every segment end
+        and recovers via -reconnect 1, so it isn't a failure."""
+        process = SharedTranscodingProcess(
+            stream_id="test_stream_eof",
+            url="http://example.com/stream.m3u8",
+            profile="test",
+            ffmpeg_args=["-i", "{input_url}", "-c", "copy", "pipe:1"],
+            user_agent="test-agent",
+        )
+
+        mock_process = Mock()
+        mock_stderr = AsyncMock()
+
+        eof_line = (
+            b"[http @ 0x7f202400c740] Error reading HTTP response: End of file\n"
+        )
+        mock_stderr.read = AsyncMock(side_effect=[eof_line, b""])
+
+        mock_process.stderr = mock_stderr
+        mock_process.returncode = None
+        process.process = mock_process
+
+        await process._log_stderr()
+
+        # Status must remain "starting" (init default), not flip to input_failed.
+        assert process.status != "input_failed"
 
 
 class TestFailoverStats:

--- a/tests/test_media_info.py
+++ b/tests/test_media_info.py
@@ -246,6 +246,193 @@ def test_parse_ffmpeg_input_line_ignores_unrelated_lines():
     assert "container" not in process.media_info
 
 
+def test_output_media_info_starts_empty_with_parser_state_unset():
+    """Fresh processes track output info separately and start in input mode."""
+    process = _make_process()
+
+    assert process.output_media_info == {}
+    assert process._parsing_output is False
+
+
+def test_parse_ffmpeg_output_line_captures_container_and_flips_state():
+    """The 'Output #0, FORMAT, to TARGET:' line should populate output_media_info
+    and switch the parser into output mode for subsequent Stream lines."""
+    process = _make_process()
+
+    process._parse_ffmpeg_output_line("Output #0, mpegts, to 'pipe:1':")
+
+    assert process.output_media_info["container"] == "MPEGTS"
+    assert process._parsing_output is True
+    # Input-side dict must not be polluted with the output container.
+    assert "container" not in process.media_info
+
+
+def test_parse_ffmpeg_output_line_takes_first_synonym():
+    """Multi-synonym output containers collapse to the first canonical name."""
+    process = _make_process()
+
+    process._parse_ffmpeg_output_line(
+        "Output #0, mov,mp4,m4a,3gp,3g2,mj2, to '/tmp/out.mp4':"
+    )
+
+    assert process.output_media_info["container"] == "MOV"
+
+
+def test_parse_ffmpeg_output_line_handles_hls_muxer():
+    """HLS output ('Output #0, hls, to ...') is the common transcoded path."""
+    process = _make_process()
+
+    process._parse_ffmpeg_output_line("Output #0, hls, to '/tmp/abc/index.m3u8':")
+
+    assert process.output_media_info["container"] == "HLS"
+
+
+def test_stream_lines_before_output_marker_go_to_input_media_info():
+    """While the parser hasn't seen Output #0, codec lines describe the source."""
+    process = _make_process()
+
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:0[0x100]: Video: hevc (Main), yuv420p, 1920x1080, 50 fps"
+    )
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:1[0x101](eng): Audio: ac3, 48000 Hz, 5.1, fltp, 384 kb/s"
+    )
+
+    assert process.media_info["video_codec"] == "hevc"
+    assert process.media_info["resolution"] == "1920x1080"
+    assert process.media_info["audio_codec"] == "ac3"
+    assert process.media_info["audio_channels"] == "5.1"
+    assert process.output_media_info == {}
+
+
+def test_stream_lines_after_output_marker_go_to_output_media_info():
+    """Once Output # is seen, the encoder Stream lines populate output_media_info,
+    leaving the input description intact."""
+    process = _make_process()
+
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:0[0x100]: Video: hevc, yuv420p, 1920x1080, 50 fps"
+    )
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:1[0x101]: Audio: ac3, 48000 Hz, 5.1, fltp, 384 kb/s"
+    )
+    process._parse_ffmpeg_output_line("Output #0, mpegts, to 'pipe:1':")
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:0: Video: h264, yuv420p, 1280x720, q=2-31, 25 fps"
+    )
+    process._parse_ffmpeg_stream_line(
+        "    Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, 128 kb/s"
+    )
+
+    # Source side untouched
+    assert process.media_info["video_codec"] == "hevc"
+    assert process.media_info["resolution"] == "1920x1080"
+    assert process.media_info["audio_codec"] == "ac3"
+    assert process.media_info["audio_channels"] == "5.1"
+    # Encoder side captured separately
+    assert process.output_media_info["video_codec"] == "h264"
+    assert process.output_media_info["resolution"] == "1280x720"
+    assert process.output_media_info["audio_codec"] == "aac"
+    assert process.output_media_info["audio_channels"] == "stereo"
+    assert process.output_media_info["container"] == "MPEGTS"
+
+
+def test_progress_fields_dual_write_once_output_seen():
+    """Progress numbers describe encoder output. Before Output #0 they only
+    populate media_info (so the existing UI keeps getting bitrate/fps even on
+    very early reads); after Output #0 they mirror into output_media_info."""
+    process = _make_process()
+
+    process._parse_ffmpeg_progress(
+        "frame=10 fps=25 bitrate=1000.0kbits/s speed=1.0x"
+    )
+    assert process.media_info["bitrate_kbps"] == 1000.0
+    assert process.media_info["fps"] == 25.0
+    assert "bitrate_kbps" not in process.output_media_info
+
+    process._parse_ffmpeg_output_line("Output #0, mpegts, to 'pipe:1':")
+    process._parse_ffmpeg_progress(
+        "frame=20 fps=30 bitrate=2000.5kbits/s speed=1.5x"
+    )
+
+    assert process.media_info["bitrate_kbps"] == 2000.5
+    assert process.media_info["fps"] == 30.0
+    assert process.output_media_info["bitrate_kbps"] == 2000.5
+    assert process.output_media_info["fps"] == 30.0
+    assert process.output_media_info["frame"] == 20
+    assert process.output_media_info["speed"] == 1.5
+
+
+def test_parse_ffmpeg_output_line_does_not_clobber_existing_container():
+    """Some configs may emit multiple Output # markers (e.g. tee); only the
+    first wins so output_media_info reflects the primary muxer."""
+    process = _make_process()
+
+    process._parse_ffmpeg_output_line("Output #0, mpegts, to 'pipe:1':")
+    process._parse_ffmpeg_output_line("Output #1, hls, to '/tmp/idx.m3u8':")
+
+    assert process.output_media_info["container"] == "MPEGTS"
+
+
+def test_get_output_media_info_returns_empty_for_non_transcoded_streams():
+    """Plain HTTP-proxy streams have no ffmpeg process — output_media_info must
+    be empty so the editor knows not to render the Output Info badge row."""
+    from stream_manager import StreamInfo, StreamManager
+    from datetime import datetime, timezone
+
+    manager = StreamManager.__new__(StreamManager)
+    manager.pooled_manager = None
+
+    stream = StreamInfo(
+        stream_id="plain-stream",
+        original_url="http://example.com/plain.ts",
+        created_at=datetime.now(timezone.utc),
+        last_access=datetime.now(timezone.utc),
+    )
+
+    assert manager._get_output_media_info(stream) == {}
+
+
+def test_get_output_media_info_pulls_from_linked_pooled_process():
+    """Transcoded streams expose the linked process's output_media_info dict so
+    encoder-side stats reach the API response alongside the input description."""
+    from stream_manager import StreamInfo, StreamManager
+    from datetime import datetime, timezone
+
+    manager = StreamManager.__new__(StreamManager)
+    pooled = MagicMock()
+    fake_process = MagicMock()
+    fake_process.output_media_info = {
+        "resolution": "1280x720",
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "audio_channels": "stereo",
+        "container": "MPEGTS",
+        "fps": 25.0,
+        "bitrate_kbps": 2500.0,
+    }
+    pooled.shared_processes = {"key-out": fake_process}
+    manager.pooled_manager = pooled
+
+    stream = StreamInfo(
+        stream_id="t-stream",
+        original_url="http://example.com/t.ts",
+        created_at=datetime.now(timezone.utc),
+        last_access=datetime.now(timezone.utc),
+        transcode_stream_key="key-out",
+    )
+
+    info = manager._get_output_media_info(stream)
+
+    assert info["resolution"] == "1280x720"
+    assert info["video_codec"] == "h264"
+    assert info["audio_codec"] == "aac"
+    assert info["audio_channels"] == "stereo"
+    assert info["container"] == "MPEGTS"
+    assert info["fps"] == 25.0
+    assert info["bitrate_kbps"] == 2500.0
+
+
 def test_force_stop_stream_does_not_clobber_concurrent_reinsertion():
     """
     Regression for failover race: force_stop_stream must tear down the process


### PR DESCRIPTION
## Summary

Pairs with the editor PR that adds an "Output" badge row to the Stream Monitor — m3ue/m3u-editor#1095. The existing `media_info` publishes the source ffmpeg is reading; this PR adds an `output_media_info` counterpart describing what ffmpeg is *producing* (encoder codec, target resolution, muxer container, plus the live progress numbers, which are technically output stats).

Also includes the fix from #55 (merged into this branch). If #55 lands first I'll rebase to drop the duplicate commit; if you'd rather have one PR, #55 can be closed in favour of this.

## What changed

**Parser state machine** (`src/pooled_stream_manager.py`)

`SharedTranscodingProcess` gains an `output_media_info: Dict[str, Any]` and a `_parsing_output: bool` flag. A new `_parse_ffmpeg_output_line` matches the `"Output #N, FORMAT, to 'TARGET':"` line ffmpeg prints once per output, captures the muxer container, and flips `_parsing_output = True`. `_parse_ffmpeg_stream_line` then routes subsequent `Stream # ... Video|Audio: ...` lines to `output_media_info` instead of `media_info`. `_parse_ffmpeg_progress` keeps writing `bitrate_kbps`/`fps`/`frame`/`speed` to `media_info` (so the existing Stream Info row in the editor doesn't regress) and additionally mirrors them into `output_media_info` once the output marker has been seen.

**API surface** (`src/stream_manager.py`)

A symmetrical `_get_output_media_info` mirrors `_get_media_info` and is included alongside `media_info` in the per-stream payload of `get_stats()`. Empty for plain HTTP-proxy streams (no ffmpeg → no encoder side) and for resolver-backed streams (yt-dlp/streamlink).

**EOF fix** (carried from #55)

Drops the bare `"end of file"` from `input_error_patterns`. ffmpeg 8.1 emits `Error reading HTTP response: End of file` on every HLS segment fetch end and silently reconnects via `-reconnect 1`, so that line was triggering false-positive failover roughly every 10 seconds against the latest `linuxserver/ffmpeg:latest`. Real upstream loss is still caught by the more specific patterns and the data-starvation detectors.

## Test plan

- [x] Stream Info badge row in the editor still populates from probe data + live ffmpeg input fields (no regression — covered by existing tests in PR #54)
- [x] Output row populates with encoder codec/resolution/audio/container/fps/bitrate from a live transcoded stream
- [x] Plain HTTP-proxy stream: `output_media_info` returned as `{}` so the editor's Output row stays hidden
- [x] HLS / yt-dlp / streamlink resolver paths: `output_media_info` empty (no ffmpeg encoder)
- [x] No segment-end-EOF false-positive failovers under ffmpeg 8.1

## Compatibility

- `media_info` shape is unchanged for existing readers (progress fields still present there)
- New `output_media_info` field is additive in the API response — older editor versions ignore it