### PR TITLE
Broadcast: audio stream tests + subtitle/seek drift correction

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -2485,11 +2485,29 @@ class BroadcastStartRequest(BaseModel):
     audio_codec: Optional[str] = None
     preset: Optional[str] = None
     hwaccel: Optional[str] = None
+    # Explicit audio stream index resolved by Laravel from the media server's own
+    # metadata for a preferred-language selection. When set, this specific stream is
+    # mapped instead of the first audio stream (index 0).
+    audio_stream_index: Optional[int] = None
+    # When set, detect embedded subtitle tracks on the source and expose the
+    # first one as a toggleable WebVTT rendition in the HLS output (master
+    # playlist + subtitle variant), rather than burning it into the video.
+    subtitles_enabled: bool = False
+    # Explicit subtitle URL resolved by Laravel from the media server's own metadata
+    # (covers embedded AND external/sidecar-file subtitles). When present, this is
+    # used directly as a second FFmpeg input instead of probing the raw video stream.
+    subtitle_url: Optional[str] = None
+    subtitle_language: Optional[str] = None
+    # Independent seek offset for subtitle_url — see BroadcastConfig.subtitle_seek_seconds.
+    subtitle_seek_seconds: Optional[int] = None
     callback_url: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
     # DVR mode: preserve all HLS segments for post-processing concat
     dvr_mode: bool = False
     metadata: Optional[dict] = None
+    # Pre-queued next programme: when the current FFmpeg exits with code 0,
+    # the proxy immediately starts this config without waiting for a Laravel round-trip.
+    next_stream_config: Optional[dict] = None
 
     @field_validator("stream_url")
     @classmethod
@@ -2499,6 +2517,13 @@ class BroadcastStartRequest(BaseModel):
     @field_validator("callback_url")
     @classmethod
     def validate_callback_url(cls, v):
+        if v is not None:
+            return validate_url(v)
+        return v
+
+    @field_validator("subtitle_url")
+    @classmethod
+    def validate_subtitle_url(cls, v):
         if v is not None:
             return validate_url(v)
         return v
@@ -2552,6 +2577,47 @@ async def start_broadcast(
     to the callback_url if provided.
     """
     try:
+        # Build optional next-programme config for zero-round-trip auto-transition.
+        next_config = None
+        if request.next_stream_config:
+            nsc = request.next_stream_config
+            try:
+                next_config = BroadcastConfig(
+                    network_id=network_id,
+                    stream_url=validate_url(nsc.get("stream_url", "")),
+                    seek_seconds=int(nsc.get("seek_seconds", 0)),
+                    duration_seconds=int(nsc.get("duration_seconds", 0)),
+                    segment_start_number=0,  # overridden at transition time
+                    add_discontinuity=False,  # set to True at transition time
+                    segment_duration=int(
+                        nsc.get("segment_duration", request.segment_duration)
+                    ),
+                    hls_list_size=int(
+                        nsc.get("hls_list_size", request.hls_list_size)
+                    ),
+                    transcode=bool(nsc.get("transcode", False)),
+                    video_bitrate=nsc.get("video_bitrate"),
+                    audio_bitrate=int(nsc.get("audio_bitrate", 192)),
+                    video_resolution=nsc.get("video_resolution"),
+                    video_codec=nsc.get("video_codec"),
+                    audio_codec=nsc.get("audio_codec"),
+                    preset=nsc.get("preset"),
+                    hwaccel=nsc.get("hwaccel"),
+                    audio_stream_index=nsc.get("audio_stream_index"),
+                    subtitles_enabled=bool(nsc.get("subtitles_enabled", False)),
+                    subtitle_url=nsc.get("subtitle_url"),
+                    subtitle_language=nsc.get("subtitle_language"),
+                    subtitle_seek_seconds=nsc.get("subtitle_seek_seconds"),
+                    callback_url=nsc.get("callback_url", request.callback_url),
+                    headers=nsc.get("headers"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"Broadcast {network_id}: invalid next_stream_config, "
+                    f"auto-transition disabled: {exc}"
+                )
+                next_config = None
+
         config = BroadcastConfig(
             network_id=network_id,
             stream_url=request.stream_url,
@@ -2569,10 +2635,16 @@ async def start_broadcast(
             audio_codec=request.audio_codec,
             preset=request.preset,
             hwaccel=request.hwaccel,
+            audio_stream_index=request.audio_stream_index,
+            subtitles_enabled=request.subtitles_enabled,
+            subtitle_url=request.subtitle_url,
+            subtitle_language=request.subtitle_language,
+            subtitle_seek_seconds=request.subtitle_seek_seconds,
             callback_url=request.callback_url,
             headers=request.headers,
             dvr_mode=request.dvr_mode,
             metadata=request.metadata,
+            next_stream_config=next_config,
         )
         status = await broadcast_manager.start_broadcast(config)
         return BroadcastStatusResponse(
@@ -2642,22 +2714,37 @@ async def get_broadcast_playlist(network_id: str) -> Response:
 @app.get("/broadcast/{network_id}/segment/{filename}")
 async def get_broadcast_segment(network_id: str, filename: str) -> FileResponse:
     """
-    Serve a segment file for a network broadcast.
+    Serve a segment or sub-playlist file for a network broadcast.
 
-    Segments are served with caching headers since they are immutable
-    once created.
+    Segments (.ts, .vtt) are served with caching headers since they are immutable
+    once created. Sub-playlists (.m3u8) — the video/subtitle variant playlists
+    referenced from the master playlist when subtitles are active — are served
+    with no-cache headers since they're rewritten as the broadcast progresses.
     """
     segment_path = broadcast_manager.get_segment_path(network_id, filename)
     if segment_path is None or not os.path.exists(segment_path):
         raise HTTPException(status_code=404, detail="Segment not found")
-    return FileResponse(
-        segment_path,
-        media_type="video/MP2T",
-        headers={
-            "Cache-Control": "max-age=86400",  # Segments are immutable
-            "Access-Control-Allow-Origin": "*",
-        },
-    )
+
+    if filename.endswith(".vtt"):
+        media_type = "text/vtt"
+    elif filename.endswith(".m3u8"):
+        media_type = "application/vnd.apple.mpegurl"
+    else:
+        media_type = "video/MP2T"
+
+    headers = {"Access-Control-Allow-Origin": "*"}
+    if media_type == "application/vnd.apple.mpegurl":
+        headers.update(
+            {
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0",
+            }
+        )
+    else:
+        headers["Cache-Control"] = "max-age=86400"  # Segments are immutable
+
+    return FileResponse(segment_path, media_type=media_type, headers=headers)
 
 
 @app.get("/broadcast/{network_id}/status", dependencies=[Depends(verify_token)])

--- a/src/broadcast_manager.py
+++ b/src/broadcast_manager.py
@@ -9,9 +9,11 @@ Manages FFmpeg processes for network broadcasting with:
 """
 
 import asyncio
+import json
 import os
 import re
 import shutil
+import subprocess
 import time
 import logging
 from dataclasses import dataclass
@@ -46,12 +48,39 @@ class BroadcastConfig:
     audio_codec: Optional[str] = None
     preset: Optional[str] = None
     hwaccel: Optional[str] = None
+    # Explicit audio stream index resolved by Laravel from the media server's own
+    # metadata for a preferred-language selection. When set, this specific stream is
+    # mapped instead of the first audio stream (index 0).
+    audio_stream_index: Optional[int] = None
+    # When set, detect an embedded subtitle track on the source and expose it as a
+    # toggleable WebVTT rendition in the HLS output (master + subtitle variant
+    # playlist), rather than burning it into the video.
+    subtitles_enabled: bool = False
+    # Explicit subtitle URL resolved by Laravel from the media server's own metadata
+    # (covers embedded AND external/sidecar-file subtitles, which a raw ffprobe of the
+    # video file can never see). When present, this is used directly as a second FFmpeg
+    # input instead of probing the raw video stream for subtitles.
+    subtitle_url: Optional[str] = None
+    subtitle_language: Optional[str] = None
+    # Seek offset the proxy must apply to the subtitle_url input.
+    #   0    -> the subtitle URL was already seeked server-side (e.g. Emby's
+    #           startPositionTicks path segment rebased the cues to zero at the same
+    #           content-time the video was seeked to). The subtitle already shares the
+    #           video's timeline origin, so the proxy adds no -ss/-itsoffset. PREFERRED.
+    #   > 0  -> a full-file subtitle that could not be seeked server-side; the proxy seeks
+    #           it locally with -ss and corrects rebasing with -itsoffset. FALLBACK.
+    # Falls back to seek_seconds when not set, for backward compatibility.
+    subtitle_seek_seconds: Optional[int] = None
     callback_url: Optional[str] = None
     # Optional custom headers to include when FFmpeg fetches the input URL
     headers: Optional[Dict[str, str]] = None
     # DVR mode: preserve all HLS segments (no rolling deletion) for post-processing
     dvr_mode: bool = False
     metadata: Optional[Dict] = None
+    # Pre-queued next programme config for zero-round-trip auto-transition.
+    # When FFmpeg exits with code 0, the process immediately starts this config
+    # instead of waiting for a Laravel callback → start round-trip.
+    next_stream_config: Optional["BroadcastConfig"] = None
 
 
 @dataclass
@@ -116,6 +145,251 @@ class NetworkBroadcastProcess:
         self._stopping = False
         self._bytes_written: int = 0  # Cumulative bytes across all segments ever seen
         self._seen_segments: Set[str] = set()  # Segment filenames already counted
+        # Populated by _resolve_subtitle_state() before the command is built.
+        # None = no subtitle stream detected (or subtitles_enabled is False) —
+        # the command falls back to the original single-playlist output.
+        # "" or a language code = a subtitle stream is present and mapped.
+        self._subtitle_language: Optional[str] = None
+        # Which FFmpeg input the mapped subtitle stream comes from: 0 = muxed into
+        # the main video file, 1 = a separate explicit subtitle_url input.
+        self._subtitle_input_index: int = 0
+        # Cached result of the video-first-PTS probe (seconds). None = not yet probed.
+        # Used to compute subtitle drift correction after a #range= byte-seek lands
+        # mid-GOP; the probe is only paid for once per BroadcastProcess instance.
+        self._cached_video_first_pts: Optional[float] = None
+
+    async def _resolve_subtitle_state(self) -> None:
+        """
+        Determine subtitle availability for the current config, preferring an explicit
+        subtitle_url (resolved by Laravel from the media server's own metadata — covers
+        embedded AND external/sidecar-file subtitles) over probing the raw video stream.
+        Falls back to ffprobe self-detection only when no explicit URL was provided,
+        which is the only option for sources without a media-server API (Local/WebDAV).
+        """
+        if self.config.subtitle_url:
+            if await self._subtitle_url_has_content(self.config.subtitle_url):
+                self._subtitle_language = self.config.subtitle_language or ""
+                self._subtitle_input_index = 1
+                return
+
+            logger.info(
+                f"Broadcast {self.network_id}: subtitle_url returned no usable "
+                "content (likely seeked past the end of the subtitle track); "
+                "continuing without subtitles"
+            )
+            self._subtitle_language = None
+            self._subtitle_input_index = 0
+            return
+
+        self._subtitle_input_index = 0
+        if not self.config.subtitles_enabled:
+            self._subtitle_language = None
+            return
+
+        self._subtitle_language = await self._probe_subtitle_language()
+        if self._subtitle_language is None:
+            logger.info(
+                f"Broadcast {self.network_id}: subtitles_enabled but no subtitle "
+                "stream detected on source; continuing without subtitles"
+            )
+
+    async def _subtitle_url_has_content(self, url: str, min_bytes: int = 10) -> bool:
+        """
+        Verify an explicit subtitle_url actually returns usable content before handing
+        it to FFmpeg as an input. Media servers' server-side seeked subtitle endpoints
+        (e.g. Emby/Jellyfin's startPositionTicks) can return HTTP 200 with a completely
+        empty body when the seek position falls after the subtitle track's last cue —
+        e.g. resuming a mid-programme broadcast past where dialogue/subtitles end, or a
+        subtitle file that's simply shorter than the video. An empty file has no
+        parseable format, so FFmpeg aborts input probing for THE WHOLE PROCESS (video
+        and audio included), not just the subtitle stream. The optional map syntax
+        (-map 1:s:0?) does not help here — it only tolerates a missing stream inside an
+        otherwise-valid container, not an input file that fails to open at all.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url)
+                return response.status_code == 200 and len(response.content) >= min_bytes
+        except Exception as e:
+            logger.warning(
+                f"Broadcast {self.network_id}: failed to validate subtitle_url, "
+                f"continuing without subtitles: {e}"
+            )
+            return False
+
+    # Bitmap/image-based subtitle codecs cannot be transcoded to WebVTT (a text
+    # format) — FFmpeg refuses with "Subtitle encoding currently only possible
+    # from text to text or bitmap to bitmap" and aborts the ENTIRE process
+    # (video and audio included), not just the subtitle output. Only accept
+    # text-based codecs here.
+    _TEXT_SUBTITLE_CODECS = {
+        "subrip",
+        "srt",
+        "ass",
+        "ssa",
+        "mov_text",
+        "webvtt",
+        "text",
+        "ttml",
+    }
+
+    async def _probe_subtitle_language(self) -> Optional[str]:
+        """
+        Probe the source for a text-based subtitle stream, returning its language
+        tag ("" if untagged), or None if no usable subtitle stream exists or the
+        probe fails/times out.
+
+        This MUST run before building the FFmpeg command: -var_stream_map
+        referencing a subtitle output that doesn't exist aborts the entire
+        FFmpeg process (video and audio included), not just the subtitle
+        track. Failing closed (None) on any doubt is intentional.
+        """
+        try:
+            cmd = [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "s",
+                "-show_entries",
+                "stream=index,codec_name:stream_tags=language",
+                "-of",
+                "json",
+                self.config.stream_url,
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning(
+                    f"Broadcast {self.network_id}: subtitle probe timed out, continuing without subtitles"
+                )
+                return None
+
+            if proc.returncode != 0:
+                return None
+
+            data = json.loads(stdout or b"{}")
+            streams = data.get("streams") or []
+            if not streams:
+                return None
+
+            # -map 0:s:0? always selects the FIRST subtitle stream in source order,
+            # so it must be the first one we inspect here too.
+            first = streams[0]
+            codec_name = (first.get("codec_name") or "").lower()
+            if codec_name not in self._TEXT_SUBTITLE_CODECS:
+                logger.info(
+                    f"Broadcast {self.network_id}: first subtitle stream is "
+                    f"'{codec_name}' (not text-based), continuing without subtitles"
+                )
+                return None
+
+            language = (first.get("tags") or {}).get("language", "") or ""
+            # Sanitize: this value is interpolated into the -var_stream_map argument,
+            # which is comma/colon-delimited. Keep it to safe identifier characters.
+            language = re.sub(r"[^a-zA-Z0-9_-]", "", language)[:10]
+            return language
+        except Exception as e:
+            logger.warning(
+                f"Broadcast {self.network_id}: subtitle probe failed, continuing without subtitles: {e}"
+            )
+            return None
+
+    def _probe_video_first_pts(self) -> float:
+        """
+        Return the first video packet's PTS (in seconds) when reading from the main
+        stream_url. Used to compute subtitle drift correction after a #range= byte-seek
+        lands mid-GOP.
+
+        After a byte-seek to offset N, ffmpeg waits for the next GOP boundary before
+        emitting the first video packet, so the first PTS is typically 1-3s (the GOP
+        size) rather than 0. The subtitle URL was server-pre-seeked to exact PTS 0 by
+        Emby's startPositionTicks, so its cues land ahead of the video without
+        correction. This probe runs once per BroadcastProcess instance; subsequent calls
+        return the cached value.
+
+        Returns 0.0 on any failure (probe timeout, ffprobe not installed, network
+        error, parse error) so the caller can skip the correction without crashing.
+        """
+        if self._cached_video_first_pts is not None:
+            return self._cached_video_first_pts
+
+        try:
+            import tempfile
+            import os
+            # ffprobe returns "N/A" for direct HTTP sources (no per-packet PTS
+            # metadata available before ffmpeg has actually read some packets),
+            # so we must first capture a tiny TS chunk to disk and probe THAT
+            # file instead. ~0.5s of stream is enough for the first GOP-boundary
+            # frame to land; the whole probe takes ~0.4s on a fast network.
+            with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as tmp:
+                tmp_path = tmp.name
+            try:
+                ffmpeg_cmd = [
+                    "ffmpeg", "-y", "-loglevel", "error",
+                    "-i", self.config.stream_url,
+                    "-t", "0.5",
+                    "-c", "copy",
+                    "-f", "mpegts",
+                    tmp_path,
+                ]
+                subprocess.run(ffmpeg_cmd, capture_output=True, text=True, timeout=10)
+                result = subprocess.run(
+                    [
+                        "ffprobe", "-v", "error",
+                        "-show_entries", "packet=pts_time",
+                        "-select_streams", "v",
+                        "-of", "csv=p=0",
+                        tmp_path,
+                    ],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0 and result.stdout:
+                    pts_str = result.stdout.strip().split("\n")[0].rstrip(",")
+                    if pts_str in ("N/A", "", "nan", "NaN"):
+                        logger.debug(
+                            f"Broadcast {self.network_id}: ffprobe returned no PTS "
+                            f"for first video packet ('{pts_str}'); skipping drift correction"
+                        )
+                        self._cached_video_first_pts = 0.0
+                        return 0.0
+                    pts = float(pts_str)
+                    self._cached_video_first_pts = pts
+                    logger.info(
+                        f"Broadcast {self.network_id}: video first PTS = {pts:.3f}s "
+                        f"(after #range= byte-seek; will apply -itsoffset +{pts:.3f} on subtitle input)"
+                    )
+                    return pts
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                f"Broadcast {self.network_id}: video PTS probe timed out after 10s; "
+                f"skipping subtitle drift correction"
+            )
+        except FileNotFoundError:
+            logger.warning(
+                f"Broadcast {self.network_id}: ffprobe not found; "
+                f"skipping subtitle drift correction"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Broadcast {self.network_id}: video PTS probe failed: {e}; "
+                f"skipping subtitle drift correction"
+            )
+
+        self._cached_video_first_pts = 0.0
+        return 0.0
 
     def _build_ffmpeg_command(self) -> List[str]:
         """Build the FFmpeg command for HLS broadcast output."""
@@ -183,14 +457,114 @@ class NetworkBroadcastProcess:
         if "-i" not in cmd:
             cmd.extend(["-i", self.config.stream_url])
 
+        # Subtitles are active either because an explicit subtitle_url was resolved by
+        # Laravel (input index 1 — a separate file, e.g. an external/sidecar subtitle) or
+        # because _probe_subtitle_language() found one muxed into the main video (input
+        # index 0). Requesting a subtitle output that doesn't exist aborts the whole
+        # process below via -var_stream_map, so this must never be assumed — only
+        # resolved/probed ahead of time by _resolve_subtitle_state().
+        subtitles_active = self._subtitle_language is not None
+
+        # A separate subtitle input MUST be added here — before -t below — so that
+        # ffmpeg's per-input option scoping doesn't misattribute -t to this input
+        # instead of applying it as the intended output-level duration limit.
+        if subtitles_active and self._subtitle_input_index == 1:
+            # Seek to match the main input's effective playback position so subtitle cue
+            # timestamps stay in sync with a resumed/seeked broadcast instead of restarting
+            # from the subtitle file's own time zero.
+            #
+            # PREFERRED PATH (subtitle_seek_seconds == 0): Laravel now asks the media server
+            # to seek the subtitle URL server-side (e.g. Emby's startPositionTicks path
+            # segment), which rebases the cues to zero at the same content-time the video was
+            # seeked to. The subtitle then already shares the video's timeline origin, so we
+            # add NO -ss / -itsoffset here — a single seek authority (the media server) drives
+            # both streams, which is what keeps them frame-locked. This is the branch that
+            # runs for Emby/Jellyfin broadcasts.
+            #
+            # EXPLICIT PATH (subtitle_seek_seconds > 0): a full-file subtitle that could not
+            # be seeked server-side. We seek it locally with -ss and correct the rebasing with
+            # -itsoffset (see below). PHP always sends this explicitly after the Jul 6
+            # single-authority fix; it relies on demuxer-specific rebasing behavior and is
+            # inherently more fragile than the server-side path.
+            #
+            # FALLBACK (subtitle_seek_seconds is None): older clients may not send
+            # subtitle_seek_seconds. Fall back to 0 (no seek) — NEVER to seek_seconds,
+            # which is the VIDEO input's seek and would push subtitle cue timestamps out
+            # of sync with the video.
+            subtitle_seek = self.config.subtitle_seek_seconds or 0
+            if subtitle_seek > 0:
+                cmd.extend(["-ss", str(subtitle_seek)])
+                # -ss skips the subtitle file's early cues but does NOT rebase the
+                # timestamps of the ones that survive — they stay absolute (relative to
+                # the subtitle file's own time zero). Emby/Jellyfin's VideoCodec=copy
+                # remux, however, DOES rebase the video's own PTS to ~0 at the seek
+                # point (confirmed via ffprobe on a live source: first video packet PTS
+                # ≈ 0, not ≈ the seek offset). Without correcting for that mismatch,
+                # every surviving subtitle cue is subtitle_seek seconds too late
+                # relative to the video it's supposed to caption. -itsoffset shifts this
+                # input's output timestamps by the same (negative) amount to re-align it
+                # with the video's rebased timeline.
+                cmd.extend(["-itsoffset", str(-subtitle_seek)])
+            # Without reconnect options, Emby/Jellyfin closing this connection mid-broadcast
+            # (observed via a lingering CLOSE-WAIT socket on a multi-hour live run) leaves
+            # ffmpeg with a dead subtitle input it never retries. Because the subtitle map
+            # below is optional (`?`), ffmpeg doesn't error out — it just silently stops
+            # emitting any further subtitle cues for the rest of the broadcast, which looks
+            # like subtitles "going out of sync" or disappearing rather than a crash.
+            cmd.extend(
+                [
+                    "-reconnect",
+                    "1",
+                    "-reconnect_streamed",
+                    "1",
+                    "-reconnect_delay_max",
+                    "10",
+                ]
+            )
+
+            # Drift correction: after a #range= byte-seek on the video input, ffmpeg waits
+            # for the next GOP boundary before emitting the first packet, so the video's
+            # first PTS is offset by the GOP size (~1-3s typically). The subtitle input
+            # was server-pre-seeked by Emby to exact PTS 0, so its cues land ahead of the
+            # video. Shift the subtitle's output timestamps forward by the video's first
+            # PTS so cues land aligned with the video's GOP start.
+            # Only probe when seek_seconds > 0 (the byte-seek path); when seek_seconds=0
+            # the video starts at PTS 0 so there is no drift to correct.
+            if self.config.seek_seconds > 0:
+                video_drift = self._probe_video_first_pts()
+                if video_drift > 0.1:  # only apply when drift is meaningful (>100ms)
+                    cmd.extend(["-itsoffset", str(video_drift)])
+
+            cmd.extend(["-i", self.config.subtitle_url])
+
         # Duration limiting for programme boundary
         if self.config.duration_seconds > 0:
             cmd.extend(["-t", str(self.config.duration_seconds)])
 
-        # Stream mapping - video + audio only (drop subtitles, data streams)
-        # Both video and audio are optional to support audio-only streams (e.g. radio stations)
-        # and video-only streams. FFmpeg silently skips missing optional streams.
-        cmd.extend(["-map", "0:v:0?", "-map", "0:a:0?"])
+        # Stream mapping - video + audio (+ subtitle, if detected). Video and audio are
+        # optional to support audio-only streams (e.g. radio stations) and video-only
+        # streams. FFmpeg silently skips missing optional streams. An explicit
+        # audio_stream_index (resolved by Laravel for a preferred-language selection)
+        # maps that specific stream instead of the default first audio stream.
+        #
+        # Laravel resolves audio_stream_index from the media server's own MediaStreams
+        # metadata, which is an ABSOLUTE index spanning video+audio+subtitle streams
+        # together (e.g. video=0, audio=1, subtitles=2..N). FFmpeg's "a:N" specifier is
+        # type-RELATIVE (the Nth audio stream) — those only coincide when audio happens
+        # to be the very first stream in the file, which is virtually never true. Using
+        # "a:N" here silently maps nothing whenever N doesn't match an actual audio-type
+        # position (the "?" swallows the miss), which then makes "-var_stream_map"'s
+        # "a:0" reference dangling and aborts the WHOLE HLS conversion — not just audio.
+        # The absolute-index form ("0:N", no type letter) selects by the same numbering
+        # Laravel resolved against, so it always lands on the right stream.
+        audio_map = (
+            f"0:{self.config.audio_stream_index}?"
+            if self.config.audio_stream_index is not None
+            else "0:a:0?"
+        )
+        cmd.extend(["-map", "0:v:0?", "-map", audio_map])
+        if subtitles_active:
+            cmd.extend(["-map", f"{self._subtitle_input_index}:s:0?"])
 
         # Codec selection
         if self.config.transcode:
@@ -220,6 +594,19 @@ class NetworkBroadcastProcess:
         else:
             cmd.extend(["-c:v", "copy", "-c:a", "copy"])
 
+        if subtitles_active:
+            cmd.extend(["-c:s", "webvtt"])
+            # HLS's #EXT-X-STREAM-INF requires a BANDWIDTH value, which FFmpeg only
+            # emits when it has an explicit bitrate for the stream. In copy mode
+            # (and whenever video_bitrate/audio_bitrate weren't already added above)
+            # there's no encoder bitrate to read, so add a hint purely for the
+            # manifest — it does not affect actual stream quality since -c:v/-c:a
+            # copy ignores -b:v/-b:a for encoding.
+            if "-b:v" not in cmd:
+                cmd.extend(["-b:v", f"{self.config.video_bitrate or 2000}k"])
+            if "-b:a" not in cmd:
+                cmd.extend(["-b:a", f"{self.config.audio_bitrate}k"])
+
         # HLS output configuration
         cmd.extend(["-f", "hls"])
         cmd.extend(["-hls_time", str(self.config.segment_duration)])
@@ -241,13 +628,30 @@ class NetworkBroadcastProcess:
             hls_flags.append("discont_start")
         cmd.extend(["-hls_flags", "+".join(hls_flags)])
 
-        # Segment filename template (6-digit zero-padded)
-        segment_pattern = os.path.join(self.hls_dir, "live%06d.ts")
-        cmd.extend(["-hls_segment_filename", segment_pattern])
+        if subtitles_active:
+            # A subtitle rendition forces FFmpeg's variant-stream mode: instead of one
+            # flat live.m3u8, it emits a master playlist referencing a video variant
+            # playlist and a subtitle variant playlist (numeric %v, no `name:` — that
+            # would substitute a string into filenames and complicate serving them).
+            var_stream_map = "v:0,a:0,s:0,sgroup:subs"
+            if self._subtitle_language:
+                var_stream_map += f",language:{self._subtitle_language}"
+            cmd.extend(["-var_stream_map", var_stream_map])
+            cmd.extend(["-master_pl_name", "master.m3u8"])
 
-        # Output playlist
-        playlist_path = os.path.join(self.hls_dir, "live.m3u8")
-        cmd.append(playlist_path)
+            segment_pattern = os.path.join(self.hls_dir, "live%v_%06d.ts")
+            cmd.extend(["-hls_segment_filename", segment_pattern])
+
+            playlist_path = os.path.join(self.hls_dir, "live_%v.m3u8")
+            cmd.append(playlist_path)
+        else:
+            # Segment filename template (6-digit zero-padded)
+            segment_pattern = os.path.join(self.hls_dir, "live%06d.ts")
+            cmd.extend(["-hls_segment_filename", segment_pattern])
+
+            # Output playlist
+            playlist_path = os.path.join(self.hls_dir, "live.m3u8")
+            cmd.append(playlist_path)
 
         return cmd
 
@@ -273,7 +677,7 @@ class NetworkBroadcastProcess:
                     if os.path.isdir(self.hls_dir)
                     else []
                 ):
-                    if filename.endswith((".ts", ".m3u8")):
+                    if filename.endswith((".ts", ".m3u8", ".vtt")):
                         try:
                             os.remove(os.path.join(self.hls_dir, filename))
                             stale_count += 1
@@ -287,6 +691,8 @@ class NetworkBroadcastProcess:
                     logger.info(
                         f"Broadcast {self.network_id}: removed {stale_count} stale file(s) before fresh start"
                     )
+
+            await self._resolve_subtitle_state()
 
             cmd = self._build_ffmpeg_command()
             logger.info(f"Starting broadcast {self.network_id}: {' '.join(cmd)}")
@@ -450,49 +856,160 @@ class NetworkBroadcastProcess:
             return
 
         try:
-            await self.process.wait()
+            while True:
+                await self.process.wait()
 
-            # Skip callback on intentional stop — the editor initiated it and handles
-            # post-processing directly without waiting for a proxy callback.
-            if self._stopping:
-                return
+                # Skip callback on intentional stop — the editor initiated it and handles
+                # post-processing directly without waiting for a proxy callback.
+                if self._stopping:
+                    return
 
-            # Determine final segment number
-            final_segment = self._get_final_segment_number()
-            self.current_segment_number = final_segment
+                # Determine final segment number
+                final_segment = self._get_final_segment_number()
+                self.current_segment_number = final_segment
 
-            # Calculate duration streamed
-            duration_streamed = 0.0
-            if self.started_at:
-                duration_streamed = (
-                    datetime.now(timezone.utc) - self.started_at
-                ).total_seconds()
+                # Calculate duration streamed
+                duration_streamed = 0.0
+                if self.started_at:
+                    duration_streamed = (
+                        datetime.now(timezone.utc) - self.started_at
+                    ).total_seconds()
 
-            exit_code = self.process.returncode
-            if exit_code == 0:
-                # Normal completion (duration limit reached) or intentional DVR stop
-                self.status = "stopped"
-                await self._send_callback(
-                    "programme_ended",
-                    {
-                        "exit_code": exit_code,
-                        "final_segment_number": final_segment,
-                        "duration_streamed": duration_streamed,
-                    },
-                )
-            else:
-                # Abnormal exit
-                self.status = "failed"
-                self.error_message = f"FFmpeg exited with code {exit_code}"
-                await self._send_callback(
-                    "broadcast_failed",
-                    {
-                        "exit_code": exit_code,
-                        "final_segment_number": final_segment,
-                        "duration_streamed": duration_streamed,
-                        "error": self.error_message,
-                    },
-                )
+                exit_code = self.process.returncode
+
+                if exit_code == 0 and self.config.next_stream_config:
+                    # Auto-transition: immediately start the next programme without
+                    # waiting for the Laravel callback → start round-trip.
+                    next_config = self.config.next_stream_config
+                    next_config.network_id = self.network_id
+                    next_config.segment_start_number = final_segment + 1
+                    next_config.add_discontinuity = True
+
+                    # Cancel old stderr/poll tasks before swapping the subprocess.
+                    for task in [self._stderr_task, self._poll_task]:
+                        if task and not task.done():
+                            task.cancel()
+                            try:
+                                await task
+                            except asyncio.CancelledError:
+                                pass
+
+                    # Reset per-segment tracking for the new programme.
+                    self._bytes_written = 0
+                    self._seen_segments = set()
+                    self.error_message = None
+                    self.config = next_config
+
+                    # Re-resolve for the new programme's content — the previous
+                    # programme's subtitle availability/language/URL does not carry over.
+                    previous_subtitles_active = self._subtitle_language is not None
+                    await self._resolve_subtitle_state()
+                    new_subtitles_active = self._subtitle_language is not None
+
+                    if previous_subtitles_active != new_subtitles_active:
+                        # The manifest shape is changing (subtitled <-> non-subtitled).
+                        # Remove the outgoing mode's manifest file(s) so
+                        # get_playlist_path()/cleanup_orphaned_segments() never mistake
+                        # a stale leftover for the current invocation's output. Segment
+                        # files (.ts/.vtt) are left alone — only manifests are mode-specific.
+                        stale_files = (
+                            ["live.m3u8"]
+                            if new_subtitles_active
+                            else ["master.m3u8", "live_0.m3u8", "live_0_vtt.m3u8"]
+                        )
+                        for stale_name in stale_files:
+                            try:
+                                os.remove(os.path.join(self.hls_dir, stale_name))
+                            except FileNotFoundError:
+                                pass
+                            except OSError as e:
+                                logger.warning(
+                                    f"Broadcast {self.network_id}: could not remove stale manifest {stale_name}: {e}"
+                                )
+
+                    logger.info(
+                        f"Broadcast {self.network_id}: auto-transitioning from "
+                        f"segment {final_segment} to next programme"
+                    )
+
+                    cmd = self._build_ffmpeg_command()
+                    logger.info(
+                        f"Broadcast {self.network_id}: starting next programme: "
+                        + " ".join(cmd[:6])
+                        + " ..."
+                    )
+
+                    try:
+                        self.process = await asyncio.create_subprocess_exec(
+                            *cmd,
+                            stdout=asyncio.subprocess.DEVNULL,
+                            stderr=asyncio.subprocess.PIPE,
+                        )
+                        self.started_at = datetime.now(timezone.utc)
+                        self.status = "running"
+                        new_pid = self.process.pid
+                        logger.info(
+                            f"Broadcast {self.network_id}: auto-transitioned, "
+                            f"PID {new_pid}, segment start "
+                            f"{next_config.segment_start_number}"
+                        )
+                    except Exception as exc:
+                        logger.error(
+                            f"Broadcast {self.network_id}: auto-transition "
+                            f"failed to start FFmpeg: {exc}"
+                        )
+                        self.status = "failed"
+                        self.error_message = str(exc)
+                        new_pid = None
+
+                    # Notify Laravel asynchronously — don't block the new process.
+                    asyncio.create_task(
+                        self._send_callback(
+                            "programme_ended",
+                            {
+                                "exit_code": exit_code,
+                                "final_segment_number": final_segment,
+                                "duration_streamed": duration_streamed,
+                                "auto_transitioned": True,
+                                "new_pid": new_pid,
+                            },
+                        )
+                    )
+
+                    if new_pid:
+                        # Restart per-process monitoring tasks and loop to watch new process.
+                        self._stderr_task = asyncio.create_task(self._log_stderr())
+                        self._poll_task = asyncio.create_task(self._poll_bytes())
+                        continue
+                    else:
+                        return
+
+                elif exit_code == 0:
+                    # Normal completion (duration limit reached) or intentional DVR stop.
+                    self.status = "stopped"
+                    await self._send_callback(
+                        "programme_ended",
+                        {
+                            "exit_code": exit_code,
+                            "final_segment_number": final_segment,
+                            "duration_streamed": duration_streamed,
+                        },
+                    )
+                    break
+                else:
+                    # Abnormal exit
+                    self.status = "failed"
+                    self.error_message = f"FFmpeg exited with code {exit_code}"
+                    await self._send_callback(
+                        "broadcast_failed",
+                        {
+                            "exit_code": exit_code,
+                            "final_segment_number": final_segment,
+                            "duration_streamed": duration_streamed,
+                            "error": self.error_message,
+                        },
+                    )
+                    break
 
         except asyncio.CancelledError:
             pass
@@ -585,8 +1102,10 @@ class NetworkBroadcastProcess:
             if not os.path.exists(self.hls_dir):
                 return self.config.segment_start_number
 
-            # Pattern: live000001.ts -> extract 000001
-            pattern = re.compile(r"live(\d{6})\.ts$")
+            # Pattern: live000001.ts -> extract 000001. When subtitles are active,
+            # segments are named live{variant}_000001.ts (e.g. live0_000001.ts) —
+            # the optional `\d+_` group tolerates that variant-index prefix.
+            pattern = re.compile(r"live(?:\d+_)?(\d{6})\.ts$")
             max_segment = self.config.segment_start_number
 
             for filename in os.listdir(self.hls_dir):
@@ -627,17 +1146,33 @@ class NetworkBroadcastProcess:
         Returns:
             Number of files removed.
         """
-        playlist_path = os.path.join(self.hls_dir, "live.m3u8")
-        if not os.path.exists(playlist_path):
-            return 0
+        # Whether subtitles are active for the CURRENT ffmpeg invocation. This must be
+        # keyed off self._subtitle_language, not "does master.m3u8 exist on disk" — a
+        # transition from subtitled to non-subtitled content (or vice versa) leaves the
+        # previous invocation's manifest file(s) on disk (stale-file cleanup is skipped
+        # during transitions to preserve segment continuity), which would otherwise make
+        # this permanently misidentify the current mode after a mode-changing transition.
+        subtitles_active = self._subtitle_language is not None
+        if subtitles_active:
+            # Referenced segments (both .ts and .vtt) are split across the video and
+            # subtitle variant playlists rather than one flat live.m3u8.
+            referenced = self.parse_playlist_segments(
+                os.path.join(self.hls_dir, "live_0.m3u8")
+            ) | self.parse_playlist_segments(
+                os.path.join(self.hls_dir, "live_0_vtt.m3u8")
+            )
+        else:
+            playlist_path = os.path.join(self.hls_dir, "live.m3u8")
+            if not os.path.exists(playlist_path):
+                return 0
+            referenced = self.parse_playlist_segments(playlist_path)
 
-        referenced = self.parse_playlist_segments(playlist_path)
         removed = 0
         now = time.time()
 
         try:
             for filename in os.listdir(self.hls_dir):
-                if not filename.endswith(".ts"):
+                if not filename.endswith((".ts", ".vtt")):
                     continue
                 if filename in referenced:
                     continue
@@ -686,15 +1221,26 @@ class NetworkBroadcastProcess:
         )
 
     def get_playlist_path(self) -> Optional[str]:
-        """Get path to the HLS playlist file."""
-        path = os.path.join(self.hls_dir, "live.m3u8")
+        """
+        Get path to the HLS playlist file for the CURRENT ffmpeg invocation.
+
+        When subtitles are active FFmpeg writes a master.m3u8 (referencing a video
+        variant + subtitle variant playlist) instead of a flat live.m3u8. This is
+        keyed off self._subtitle_language rather than "does master.m3u8 exist on
+        disk" — a transition from subtitled to non-subtitled content (or vice versa)
+        leaves the previous invocation's manifest file on disk (stale-file cleanup
+        is skipped during transitions to preserve segment continuity), which would
+        otherwise keep serving a stale master/flat playlist after the mode changes.
+        """
+        filename = "master.m3u8" if self._subtitle_language is not None else "live.m3u8"
+        path = os.path.join(self.hls_dir, filename)
         return path if os.path.exists(path) else None
 
     def get_segment_path(self, filename: str) -> Optional[str]:
-        """Get path to a specific segment file."""
+        """Get path to a specific segment or sub-playlist file."""
         # Sanitize filename to prevent directory traversal
         safe_filename = os.path.basename(filename)
-        if not safe_filename.endswith(".ts"):
+        if not safe_filename.endswith((".ts", ".vtt", ".m3u8")):
             return None
 
         path = os.path.join(self.hls_dir, safe_filename)
@@ -922,10 +1468,12 @@ class BroadcastManager:
     async def read_playlist(self, network_id: str) -> Optional[str]:
         """Read the HLS playlist content for a network."""
         if network_id not in self.broadcasts:
-            # Check if directory exists even without active broadcast (for recovery)
-            playlist_path = os.path.join(
-                self.hls_base_dir, f"broadcast_{network_id}", "live.m3u8"
-            )
+            # Check if directory exists even without active broadcast (for recovery).
+            # Prefer master.m3u8 (subtitles active) over the flat live.m3u8.
+            broadcast_dir = os.path.join(self.hls_base_dir, f"broadcast_{network_id}")
+            playlist_path = os.path.join(broadcast_dir, "master.m3u8")
+            if not os.path.exists(playlist_path):
+                playlist_path = os.path.join(broadcast_dir, "live.m3u8")
             if os.path.exists(playlist_path):
                 try:
                     with open(playlist_path, "r") as f:
@@ -948,10 +1496,10 @@ class BroadcastManager:
             return None
 
     def get_segment_path(self, network_id: str, filename: str) -> Optional[str]:
-        """Get path to a segment file for a network."""
+        """Get path to a segment or sub-playlist file for a network."""
         # Sanitize filename
         safe_filename = os.path.basename(filename)
-        if not safe_filename.endswith(".ts"):
+        if not safe_filename.endswith((".ts", ".vtt", ".m3u8")):
             return None
 
         # Check active broadcast first

--- a/src/broadcast_manager.py
+++ b/src/broadcast_manager.py
@@ -336,38 +336,59 @@ class NetworkBroadcastProcess:
                 ffmpeg_cmd = [
                     "ffmpeg", "-y", "-loglevel", "error",
                     "-i", self.config.stream_url,
-                    "-t", "0.5",
+                    "-t", "1.0",  # 1.0s — long enough to ensure TS sync + first GOP
                     "-c", "copy",
                     "-f", "mpegts",
                     tmp_path,
                 ]
-                subprocess.run(ffmpeg_cmd, capture_output=True, text=True, timeout=10)
+                subprocess.run(ffmpeg_cmd, capture_output=True, text=True, timeout=15)
+                # Don't `-select_streams v`: some byte-seek positions land on fragments
+                # where ffmpeg's bin parser doesn't register a typed "video" stream
+                # (the cut falls between TS sync + PES headers), so the video filter
+                # returns empty stdout. Without the filter, the FIRST packet's PTS
+                # is reliably the GOP-boundary marker for whatever stream it belongs to;
+                # the audio packet right next to the video one has effectively the
+                # same offset (~1-3s after byte-seek), so audio PTS is a valid proxy
+                # for the GOP drift.
                 result = subprocess.run(
                     [
                         "ffprobe", "-v", "error",
                         "-show_entries", "packet=pts_time",
-                        "-select_streams", "v",
                         "-of", "csv=p=0",
                         tmp_path,
                     ],
                     capture_output=True, text=True, timeout=5,
                 )
                 if result.returncode == 0 and result.stdout:
-                    pts_str = result.stdout.strip().split("\n")[0].rstrip(",")
-                    if pts_str in ("N/A", "", "nan", "NaN"):
+                    # Parse the first non-blank, parseable PTS line.
+                    pts = None
+                    for line in result.stdout.splitlines():
+                        candidate = line.rstrip(",").strip()
+                        if not candidate or candidate in ("N/A", "nan", "NaN"):
+                            continue
+                        try:
+                            pts = float(candidate)
+                            break
+                        except ValueError:
+                            continue
+                    if pts is None:
                         logger.debug(
-                            f"Broadcast {self.network_id}: ffprobe returned no PTS "
-                            f"for first video packet ('{pts_str}'); skipping drift correction"
+                            f"Broadcast {self.network_id}: ffprobe returned no usable PTS "
+                            f"in tmp file; skipping drift correction"
                         )
                         self._cached_video_first_pts = 0.0
                         return 0.0
-                    pts = float(pts_str)
                     self._cached_video_first_pts = pts
                     logger.info(
                         f"Broadcast {self.network_id}: video first PTS = {pts:.3f}s "
                         f"(after #range= byte-seek; will apply -itsoffset +{pts:.3f} on subtitle input)"
                     )
                     return pts
+                else:
+                    logger.debug(
+                        f"Broadcast {self.network_id}: ffprobe returned empty stdout "
+                        f"(rc={result.returncode}); skipping drift correction"
+                    )
             finally:
                 try:
                     os.unlink(tmp_path)

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -460,6 +460,7 @@ class StreamManager:
             or "/timeshift/" in url_lower
             or "/movie/" in url_lower
             or "/series/" in url_lower
+            or "/dvr/recordings/" in url_lower
         ):
             return (False, True, False)
 

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -460,7 +460,6 @@ class StreamManager:
             or "/timeshift/" in url_lower
             or "/movie/" in url_lower
             or "/series/" in url_lower
-            or "/dvr/recordings/" in url_lower
         ):
             return (False, True, False)
 

--- a/tests/test_broadcast_audio.py
+++ b/tests/test_broadcast_audio.py
@@ -1,0 +1,52 @@
+from src.broadcast_manager import BroadcastConfig, NetworkBroadcastProcess
+
+
+def test_command_defaults_to_first_audio_stream_when_no_index_given():
+    cfg = BroadcastConfig(network_id="audiodefault", stream_url="http://example.com/video.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    cmd = proc._build_ffmpeg_command()
+
+    assert "0:a:0?" in cmd
+
+
+def test_command_maps_explicit_audio_stream_index():
+    """
+    Laravel resolves audio_stream_index from the media server's MediaStreams
+    metadata, which is an ABSOLUTE index spanning video+audio+subtitle streams
+    together — not FFmpeg's type-relative "a:N" (Nth audio stream). Mapping it
+    with a type letter silently maps nothing whenever the absolute index doesn't
+    also happen to be a valid per-type audio position, which then aborts the
+    whole HLS conversion when -var_stream_map's "a:0" reference goes dangling.
+    """
+    cfg = BroadcastConfig(
+        network_id="audiotest",
+        stream_url="http://example.com/video.mkv",
+        audio_stream_index=2,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    cmd = proc._build_ffmpeg_command()
+
+    assert "0:2?" in cmd
+    assert "0:a:2?" not in cmd
+    assert "0:a:0?" not in cmd
+
+
+def test_command_maps_audio_stream_index_zero_explicitly():
+    """
+    Regression guard: audio_stream_index=0 must not be treated as falsy/unset —
+    only None means "no preference". An explicit 0 still uses the absolute-index
+    form ("0:0?"), distinct from the type-relative default ("0:a:0?").
+    """
+    cfg = BroadcastConfig(
+        network_id="audiozero",
+        stream_url="http://example.com/video.mkv",
+        audio_stream_index=0,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    cmd = proc._build_ffmpeg_command()
+
+    assert "0:0?" in cmd
+    assert "0:a:0?" not in cmd
+    map_indices = [i for i, arg in enumerate(cmd) if arg == "-map"]
+    audio_maps = [cmd[i + 1] for i in map_indices if cmd[i + 1].startswith("0:") and not cmd[i + 1].startswith("0:v:")]
+    assert audio_maps == ["0:0?"]

--- a/tests/test_broadcast_subtitles.py
+++ b/tests/test_broadcast_subtitles.py
@@ -1,0 +1,804 @@
+import json
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.broadcast_manager import BroadcastConfig, NetworkBroadcastProcess
+
+
+def _proc_with_language(language, **config_kwargs):
+    cfg = BroadcastConfig(
+        network_id="subtest",
+        stream_url="http://example.com/video.mkv",
+        subtitles_enabled=True,
+        **config_kwargs,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = language
+    return proc
+
+
+def _mock_httpx_get(status_code=200, content=b"1\n00:00:01,000 --> 00:00:02,000\nHi\n"):
+    """Mock httpx.AsyncClient()... .get(url) for _subtitle_url_has_content()."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.content = content
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    return patch("httpx.AsyncClient", return_value=mock_client)
+
+
+def test_command_unchanged_when_subtitles_disabled():
+    cfg = BroadcastConfig(
+        network_id="nosub", stream_url="http://example.com/video.mkv"
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    cmd = proc._build_ffmpeg_command()
+
+    assert "-var_stream_map" not in cmd
+    assert "-c:s" not in cmd
+    assert cmd[-1] == "/tmp/broadcast_nosub/live.m3u8"
+    assert "-hls_segment_filename" in cmd
+    seg_idx = cmd.index("-hls_segment_filename")
+    assert cmd[seg_idx + 1] == "/tmp/broadcast_nosub/live%06d.ts"
+
+
+def test_command_falls_back_when_subtitles_enabled_but_none_detected():
+    proc = _proc_with_language(None)
+    cmd = proc._build_ffmpeg_command()
+
+    # No subtitle stream was found by the probe -> identical to the disabled case.
+    assert "-var_stream_map" not in cmd
+    assert "-c:s" not in cmd
+    assert cmd[-1] == "/tmp/broadcast_subtest/live.m3u8"
+
+
+def test_command_builds_master_variant_when_subtitle_detected():
+    proc = _proc_with_language("eng")
+    cmd = proc._build_ffmpeg_command()
+
+    assert "-map" in cmd
+    assert "0:s:0?" in cmd
+    assert "-c:s" in cmd
+    assert cmd[cmd.index("-c:s") + 1] == "webvtt"
+
+    assert "-var_stream_map" in cmd
+    var_stream_map = cmd[cmd.index("-var_stream_map") + 1]
+    assert var_stream_map == "v:0,a:0,s:0,sgroup:subs,language:eng"
+
+    assert "-master_pl_name" in cmd
+    assert cmd[cmd.index("-master_pl_name") + 1] == "master.m3u8"
+
+    seg_idx = cmd.index("-hls_segment_filename")
+    assert cmd[seg_idx + 1] == "/tmp/broadcast_subtest/live%v_%06d.ts"
+    assert cmd[-1] == "/tmp/broadcast_subtest/live_%v.m3u8"
+
+
+def test_command_omits_language_attribute_when_subtitle_untagged():
+    proc = _proc_with_language("")
+    cmd = proc._build_ffmpeg_command()
+
+    var_stream_map = cmd[cmd.index("-var_stream_map") + 1]
+    assert var_stream_map == "v:0,a:0,s:0,sgroup:subs"
+    assert "language:" not in var_stream_map
+
+
+def test_command_adds_manifest_only_bitrate_hints_in_copy_mode():
+    proc = _proc_with_language("eng", transcode=False)
+    cmd = proc._build_ffmpeg_command()
+
+    # -c:v/-c:a copy must be unaffected (no re-encode) even with hints added.
+    assert "-c:v" in cmd
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert "-b:v" in cmd
+    assert "-b:a" in cmd
+
+
+def test_command_does_not_duplicate_bitrate_flags_in_transcode_mode():
+    proc = _proc_with_language(
+        "eng", transcode=True, video_bitrate="4000", audio_bitrate=256
+    )
+    cmd = proc._build_ffmpeg_command()
+
+    assert cmd.count("-b:v") == 1
+    assert cmd.count("-b:a") == 1
+    assert cmd[cmd.index("-b:v") + 1] == "4000k"
+    assert cmd[cmd.index("-b:a") + 1] == "256k"
+
+
+@pytest.mark.asyncio
+async def test_probe_subtitle_language_returns_language_from_ffprobe():
+    cfg = BroadcastConfig(
+        network_id="probetest",
+        stream_url="http://example.com/video.mkv",
+        subtitles_enabled=True,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    fake_stdout = json.dumps(
+        {
+            "streams": [
+                {"index": 2, "codec_name": "subrip", "tags": {"language": "eng"}}
+            ]
+        }
+    ).encode()
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(fake_stdout, b""))
+    mock_proc.returncode = 0
+
+    with patch(
+        "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
+    ):
+        language = await proc._probe_subtitle_language()
+
+    assert language == "eng"
+
+
+@pytest.mark.asyncio
+async def test_probe_subtitle_language_returns_none_for_bitmap_subtitle_codec():
+    """
+    Bitmap subtitle formats (PGS, VobSub/dvd_subtitle, DVB) can't be transcoded
+    to WebVTT — FFmpeg aborts the entire process (video+audio included) if asked
+    to. The probe must reject these so the broadcast falls back to no subtitles
+    instead of crash-looping.
+    """
+    cfg = BroadcastConfig(
+        network_id="probetest-bitmap",
+        stream_url="http://example.com/video.mkv",
+        subtitles_enabled=True,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    fake_stdout = json.dumps(
+        {
+            "streams": [
+                {
+                    "index": 2,
+                    "codec_name": "hdmv_pgs_subtitle",
+                    "tags": {"language": "eng"},
+                }
+            ]
+        }
+    ).encode()
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(fake_stdout, b""))
+    mock_proc.returncode = 0
+
+    with patch(
+        "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
+    ):
+        language = await proc._probe_subtitle_language()
+
+    assert language is None
+
+
+@pytest.mark.asyncio
+async def test_probe_subtitle_language_returns_none_when_no_streams():
+    cfg = BroadcastConfig(
+        network_id="probetest2",
+        stream_url="http://example.com/video.mkv",
+        subtitles_enabled=True,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(b'{"streams": []}', b""))
+    mock_proc.returncode = 0
+
+    with patch(
+        "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
+    ):
+        language = await proc._probe_subtitle_language()
+
+    assert language is None
+
+
+@pytest.mark.asyncio
+async def test_probe_subtitle_language_fails_closed_on_probe_error():
+    cfg = BroadcastConfig(
+        network_id="probetest3",
+        stream_url="http://example.com/video.mkv",
+        subtitles_enabled=True,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
+    mock_proc.returncode = 1
+
+    with patch(
+        "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
+    ):
+        language = await proc._probe_subtitle_language()
+
+    assert language is None
+
+
+def test_final_segment_number_matches_variant_prefixed_filenames(tmp_path):
+    hls_dir = tmp_path / "broadcast_segnum"
+    hls_dir.mkdir()
+    (hls_dir / "live0_000000.ts").write_bytes(b"x")
+    (hls_dir / "live0_000005.ts").write_bytes(b"x")
+
+    cfg = BroadcastConfig(network_id="segnum", stream_url="http://example.com/v.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir=str(tmp_path))
+
+    assert proc._get_final_segment_number() == 5
+
+
+def test_get_playlist_path_uses_current_subtitle_state_not_disk_presence(tmp_path):
+    """
+    Regression test: get_playlist_path() must be keyed off self._subtitle_language
+    (the CURRENT ffmpeg invocation's state), not "does master.m3u8 exist on disk".
+    A stale master.m3u8 left over from a previous, subtitled programme (stale-file
+    cleanup is skipped during transitions to preserve segment continuity) must NOT
+    be served once the current programme has no subtitles.
+    """
+    hls_dir = tmp_path / "broadcast_pathtest"
+    hls_dir.mkdir()
+    (hls_dir / "live.m3u8").write_text("flat")
+    (hls_dir / "master.m3u8").write_text("stale master from a previous subtitled programme")
+
+    cfg = BroadcastConfig(network_id="pathtest", stream_url="http://example.com/v.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir=str(tmp_path))
+
+    proc._subtitle_language = None
+    assert proc.get_playlist_path() == str(hls_dir / "live.m3u8")
+
+    proc._subtitle_language = "eng"
+    assert proc.get_playlist_path() == str(hls_dir / "master.m3u8")
+
+
+def test_get_segment_path_allows_vtt_and_m3u8(tmp_path):
+    hls_dir = tmp_path / "broadcast_segpath"
+    hls_dir.mkdir()
+    (hls_dir / "live_00.vtt").write_text("WEBVTT")
+    (hls_dir / "live_0.m3u8").write_text("#EXTM3U")
+    (hls_dir / "notes.txt").write_text("nope")
+
+    cfg = BroadcastConfig(network_id="segpath", stream_url="http://example.com/v.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir=str(tmp_path))
+
+    assert proc.get_segment_path("live_00.vtt") == str(hls_dir / "live_00.vtt")
+    assert proc.get_segment_path("live_0.m3u8") == str(hls_dir / "live_0.m3u8")
+    assert proc.get_segment_path("notes.txt") is None
+
+
+def test_cleanup_orphaned_segments_handles_master_variant_layout(tmp_path):
+    hls_dir = tmp_path / "broadcast_cleanup"
+    hls_dir.mkdir()
+    (hls_dir / "master.m3u8").write_text("#EXTM3U\n")
+    (hls_dir / "live_0.m3u8").write_text("#EXTM3U\nlive0_000001.ts\n")
+    (hls_dir / "live_0_vtt.m3u8").write_text("#EXTM3U\nlive_001.vtt\n")
+    (hls_dir / "live0_000001.ts").write_bytes(b"x")  # referenced -> keep
+    (hls_dir / "live0_000000.ts").write_bytes(b"x")  # orphaned -> remove
+    (hls_dir / "live_001.vtt").write_text("WEBVTT")  # referenced -> keep
+    (hls_dir / "live_000.vtt").write_text("WEBVTT")  # orphaned -> remove
+
+    cfg = BroadcastConfig(network_id="cleanup", stream_url="http://example.com/v.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir=str(tmp_path))
+    proc._subtitle_language = "eng"  # current invocation has subtitles active
+
+    removed = proc.cleanup_orphaned_segments(age_threshold=0)
+
+    assert removed == 2
+    assert (hls_dir / "live0_000001.ts").exists()
+    assert (hls_dir / "live_001.vtt").exists()
+    assert not (hls_dir / "live0_000000.ts").exists()
+    assert not (hls_dir / "live_000.vtt").exists()
+    # Manifest files are never treated as orphaned segments.
+    assert (hls_dir / "master.m3u8").exists()
+    assert (hls_dir / "live_0.m3u8").exists()
+    assert (hls_dir / "live_0_vtt.m3u8").exists()
+
+
+def test_cleanup_orphaned_segments_ignores_stale_master_after_transition_to_flat(
+    tmp_path,
+):
+    """
+    Regression test for a transition bug: after a program transition from
+    subtitled -> non-subtitled content, a stale master.m3u8/live_0*.m3u8 from the
+    previous invocation can still be on disk (stale-file cleanup is skipped during
+    transitions). cleanup_orphaned_segments() must use the flat live.m3u8 (the
+    CURRENT invocation's manifest), not fall back to the stale master layout just
+    because master.m3u8 happens to still exist.
+    """
+    hls_dir = tmp_path / "broadcast_stalemaster"
+    hls_dir.mkdir()
+    # Stale leftovers from the previous (subtitled) programme.
+    (hls_dir / "master.m3u8").write_text("#EXTM3U\n")
+    (hls_dir / "live_0.m3u8").write_text("#EXTM3U\nlive0_000000.ts\n")
+    (hls_dir / "live_0_vtt.m3u8").write_text("#EXTM3U\nlive_00.vtt\n")
+    # Current (non-subtitled) invocation's real manifest and segment.
+    (hls_dir / "live.m3u8").write_text("#EXTM3U\nlive000001.ts\n")
+    (hls_dir / "live000001.ts").write_bytes(b"x")  # referenced by live.m3u8 -> keep
+
+    cfg = BroadcastConfig(network_id="stalemaster", stream_url="http://example.com/v.mkv")
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir=str(tmp_path))
+    proc._subtitle_language = None  # current invocation has no subtitles
+
+    removed = proc.cleanup_orphaned_segments(age_threshold=0)
+
+    assert removed == 0
+    assert (hls_dir / "live000001.ts").exists()
+
+
+def test_command_adds_second_input_for_explicit_subtitle_url():
+    cfg = BroadcastConfig(
+        network_id="exturl",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/Videos/1/mediasource_1/Subtitles/2/Stream.srt",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    # Both inputs present, subtitle input after the main video input.
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    assert len(i_indices) == 2
+    assert cmd[i_indices[0] + 1] == "http://emby.local/video.ts"
+    assert cmd[i_indices[1] + 1] == cfg.subtitle_url
+
+    # Subtitle mapped from input 1, not input 0.
+    assert "1:s:0?" in cmd
+    assert "0:s:0?" not in cmd
+
+    # -t must come after BOTH -i's, or ffmpeg would scope it to the subtitle input
+    # instead of applying it as the output-level duration limit.
+    t_idx = cmd.index("-t") if "-t" in cmd else None
+    if t_idx is not None:
+        assert t_idx > i_indices[1]
+
+
+def test_passing_both_seek_seconds_zero_and_subtitle_seek_seconds_zero_applies_neither():
+    """
+    CONTRACT test: the ONLY way to signal "no seek needed" is to send both
+    seek_seconds=0 AND subtitle_seek_seconds=0. When that combination arrives, the
+    proxy must NOT apply -ss to the video input AND must NOT apply -ss/-itsoffset
+    to the subtitle input. This locks the single-authority contract: the media server
+    is the sole seek authority for both streams, and the proxy leaves them untouched.
+    """
+    cfg = BroadcastConfig(
+        network_id="preseek",
+        # Video seeked server-side (StartTimeTicks) -> seek_seconds zeroed by Laravel.
+        stream_url="http://emby.local/video.ts?StartTimeTicks=84500000000&VideoCodec=copy",
+        # Subtitle URL carries the startPositionTicks path segment: already rebased.
+        subtitle_url="http://emby.local/Videos/1/mediasource_1/Subtitles/3/8450000000/Stream.srt",
+        seek_seconds=0,
+        subtitle_seek_seconds=0,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    # The pre-seeked subtitle URL is added as-is, with no local seeking of any input.
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    assert len(i_indices) == 2
+    assert cmd[i_indices[1] + 1] == cfg.subtitle_url
+    assert "-ss" not in cmd
+    assert "-itsoffset" not in cmd
+
+
+def test_command_applies_input_seek_to_rewritten_static_url():
+    """
+    Regression test for the Emby VideoCodec=copy remux seek bug: PHP rewrites the
+    remux URL (strips VideoCodec=copy AND StartTimeTicks, adds static=true) so the
+    static endpoint is hit. Emby ignores StartTimeTicks server-side on BOTH static
+    and remux (verified against a live Emby via md5). The static endpoint DOES
+    support byte-range requests (Accept-Ranges: bytes), so the proxy must apply
+    ffmpeg input -ss against it — that's how the seek actually happens.
+    """
+    cfg = BroadcastConfig(
+        network_id="remux_rewritten",
+        # What PHP sends after rewrite: static URL with AudioStreamIndex.
+        # VideoCodec=copy and StartTimeTicks were both stripped (Emby ignores
+        # them on static), static=true was added.
+        stream_url="http://emby.local/Videos/1/stream.ts?api_key=abc&AudioStreamIndex=1&static=true",
+        seek_seconds=2715,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    cmd = proc._build_ffmpeg_command()
+
+    # Input-level -ss must be present, before the main -i, with the correct value.
+    assert "-ss" in cmd
+    ss_idx = cmd.index("-ss")
+    assert cmd[ss_idx + 1] == "2715"
+
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    assert ss_idx < i_indices[0]
+
+
+def test_command_applies_input_seek_when_stream_url_has_seek_param():
+    """
+    Regression test for the Emby VideoCodec=copy remux seek bug: PHP rewrites the
+    remux URL to the seek-capable static endpoint (strips VideoCodec=copy, keeps
+    StartTimeTicks + AudioStreamIndex) and sends seek_seconds > 0. The proxy must
+    apply ffmpeg input -ss so the seek actually happens. Before this fix PHP
+    zeroed seek_seconds for any remux URL, so ffmpeg played from byte 0.
+    """
+    cfg = BroadcastConfig(
+        network_id="remux_seek",
+        # PHP-rewritten URL: VideoCodec=copy stripped, StartTimeTicks kept.
+        # Looks like a static+seeked URL because that's what it now is.
+        stream_url="http://emby.local/Videos/1/stream.ts?api_key=abc&StartTimeTicks=27150000000&AudioStreamIndex=1",
+        seek_seconds=2715,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    # Input-level -ss must be present, before the main -i, with the correct value.
+    assert "-ss" in cmd
+    ss_idx = cmd.index("-ss")
+    assert cmd[ss_idx + 1] == "2715"
+
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    assert ss_idx < i_indices[0]
+
+    # The full rebase-to-zero anti-desync contract still holds: the subtitle input
+    # arrives pre-seeked by Emby (subtitle_seek_seconds=0), so NO -ss/-itsoffset on it.
+    assert "-itsoffset" not in cmd
+
+
+def test_command_seeks_subtitle_input_to_match_video_seek():
+    cfg = BroadcastConfig(
+        network_id="seeksub",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/sub.srt",
+        seek_seconds=120,
+        # Explicit fallback-path setup: PHP sends the same seek value for the
+        # subtitle input. (When subtitle_seek_seconds is omitted the proxy now
+        # falls back to 0 — see test_subtitle_input_falls_back_to_zero_when_*
+        # — so this test must set it explicitly to exercise the
+        # "-ss + -itsoffset" branch.)
+        subtitle_seek_seconds=120,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    ss_indices = [i for i, arg in enumerate(cmd) if arg == "-ss"]
+
+    # One -ss before each -i (video input, then subtitle input).
+    assert len(ss_indices) == 2
+    for ss_idx in ss_indices:
+        assert cmd[ss_idx + 1] == "120"
+    assert ss_indices[0] < i_indices[0]
+    assert ss_indices[1] < i_indices[1]
+
+    # The subtitle input also gets a negative -itsoffset to compensate for the
+    # seek rebasing its output timestamps back to absolute (see
+    # test_command_shifts_subtitle_timestamps_to_match_rebased_video_pts).
+    assert "-itsoffset" in cmd
+    itsoffset_idx = cmd.index("-itsoffset")
+    assert cmd[itsoffset_idx + 1] == "-120"
+
+
+def test_subtitle_input_falls_back_to_zero_when_subtitle_seek_seconds_omitted():
+    """
+    When subtitle_seek_seconds is not set (None), the proxy must NOT fall back to
+    seek_seconds for the subtitle input — it must fall back to 0 (no seek).
+    Fallback to seek_seconds would apply a -ss/-itsoffset offset meant for the VIDEO
+    input to the SUBTITLE input, pushing subtitle cue timestamps out of sync.
+    """
+    cfg = BroadcastConfig(
+        network_id="fallback-zero",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/sub.srt",
+        seek_seconds=2715,
+        # subtitle_seek_seconds intentionally omitted (None)
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    # Video input gets -ss 2715 as expected.
+    assert "-ss" in cmd
+    ss_idx = cmd.index("-ss")
+    assert cmd[ss_idx + 1] == "2715"
+
+    # Subtitle input gets NO -ss / -itsoffset — fallback is 0, not seek_seconds.
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    assert len(i_indices) == 2
+    # -ss appears before the FIRST -i (video input), nothing before the second.
+    assert ss_idx < i_indices[0]
+    assert "-itsoffset" not in cmd
+
+
+def test_command_shifts_subtitle_timestamps_to_match_rebased_video_pts():
+    """
+    Regression test for a real production desync: subtitles playing badly out of
+    sync (dialogue that looks like it's "for a different movie") whenever a
+    broadcast resumes with a non-zero seek.
+
+    Root cause, confirmed against a live Emby source with ffprobe: a
+    VideoCodec=copy remux REBASES the video's own PTS to ~0 at the seek point
+    (first video packet PTS ≈ 0, not ≈ the seek offset). But ffmpeg's -ss on the
+    subtitle_url input only skips early cues — it does NOT rebase the surviving
+    ones, which stay on the subtitle file's own absolute timeline. Without
+    correcting for that mismatch, every subtitle cue ends up subtitle_seek
+    seconds later than the video position it's meant to caption. -itsoffset
+    (negative, equal in magnitude to the seek) shifts the subtitle input back
+    onto the video's rebased timeline.
+    """
+    cfg = BroadcastConfig(
+        network_id="rebase",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/sub.srt",
+        subtitle_seek_seconds=69,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    ss_idx = cmd.index("-ss")
+    itsoffset_idx = cmd.index("-itsoffset")
+
+    assert cmd[ss_idx + 1] == "69"
+    assert cmd[itsoffset_idx + 1] == "-69"
+    # Both must land before the subtitle -i, and -itsoffset must not leak onto
+    # the main video input.
+    assert ss_idx < i_indices[1]
+    assert itsoffset_idx < i_indices[1]
+    assert cmd[: i_indices[0] + 2].count("-itsoffset") == 0
+
+
+def test_command_omits_itsoffset_when_there_is_no_seek():
+    cfg = BroadcastConfig(
+        network_id="noseek",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/sub.srt",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    assert "-itsoffset" not in cmd
+
+
+def test_command_reconnects_the_subtitle_input_on_dropped_connections():
+    cfg = BroadcastConfig(
+        network_id="subreconnect",
+        stream_url="http://emby.local/video.ts",
+        subtitle_url="http://emby.local/sub.srt",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    cmd = proc._build_ffmpeg_command()
+
+    i_indices = [i for i, arg in enumerate(cmd) if arg == "-i"]
+    between_inputs = cmd[i_indices[0] + 1 : i_indices[1]]
+
+    # The subtitle input must get its own reconnect options — without them,
+    # Emby/Jellyfin closing this connection mid-broadcast leaves ffmpeg with a
+    # dead subtitle input it never retries, silently dropping all further
+    # subtitle cues for the rest of the broadcast.
+    assert between_inputs.count("-reconnect") == 1
+    assert between_inputs[between_inputs.index("-reconnect") + 1] == "1"
+    assert between_inputs[between_inputs.index("-reconnect_streamed") + 1] == "1"
+    assert between_inputs[between_inputs.index("-reconnect_delay_max") + 1] == "10"
+
+
+@pytest.mark.asyncio
+async def test_resolve_subtitle_state_prefers_explicit_url_and_skips_probing():
+    cfg = BroadcastConfig(
+        network_id="prefer-url",
+        stream_url="http://emby.local/video.ts",
+        subtitles_enabled=True,
+        subtitle_url="http://emby.local/sub.srt",
+        subtitle_language="fre",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec, _mock_httpx_get():
+        await proc._resolve_subtitle_state()
+
+    mock_exec.assert_not_called()
+    assert proc._subtitle_language == "fre"
+    assert proc._subtitle_input_index == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_subtitle_state_falls_back_when_subtitle_url_is_empty():
+    """
+    Media servers' server-side seeked subtitle endpoints (e.g. Emby/Jellyfin's
+    startPositionTicks) can return HTTP 200 with a completely empty body when the
+    seek lands past the subtitle track's last cue. FFmpeg can't open an empty file
+    at all, which would otherwise abort the whole broadcast (video+audio included).
+    """
+    cfg = BroadcastConfig(
+        network_id="empty-url",
+        stream_url="http://emby.local/video.ts",
+        subtitles_enabled=True,
+        subtitle_url="http://emby.local/sub.srt",
+        subtitle_language="eng",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    with _mock_httpx_get(status_code=200, content=b""):
+        await proc._resolve_subtitle_state()
+
+    assert proc._subtitle_language is None
+    assert proc._subtitle_input_index == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_subtitle_state_falls_back_when_subtitle_url_fetch_fails():
+    cfg = BroadcastConfig(
+        network_id="broken-url",
+        stream_url="http://emby.local/video.ts",
+        subtitles_enabled=True,
+        subtitle_url="http://emby.local/sub.srt",
+        subtitle_language="eng",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    with patch("httpx.AsyncClient", side_effect=RuntimeError("connection failed")):
+        await proc._resolve_subtitle_state()
+
+    assert proc._subtitle_language is None
+    assert proc._subtitle_input_index == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_subtitle_state_falls_back_to_probe_without_url():
+    cfg = BroadcastConfig(
+        network_id="fallback-probe",
+        stream_url="http://emby.local/video.ts",
+        subtitles_enabled=True,
+        subtitle_url=None,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(
+        return_value=(
+            json.dumps(
+                {"streams": [{"codec_name": "subrip", "tags": {"language": "spa"}}]}
+            ).encode(),
+            b"",
+        )
+    )
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        await proc._resolve_subtitle_state()
+
+    assert proc._subtitle_language == "spa"
+    assert proc._subtitle_input_index == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_subtitle_state_untagged_language_defaults_to_empty_string():
+    cfg = BroadcastConfig(
+        network_id="untagged-url",
+        stream_url="http://emby.local/video.ts",
+        subtitles_enabled=True,
+        subtitle_url="http://emby.local/sub.srt",
+        subtitle_language=None,
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    with _mock_httpx_get():
+        await proc._resolve_subtitle_state()
+
+    assert proc._subtitle_language == ""
+    assert proc._subtitle_input_index == 1
+
+
+def test_command_subtitle_drift_correction_probe_applies_itsoffset(monkeypatch):
+    """
+    Regression test for the user-reported "subtitles a tad bit slow or fast" symptom
+    in path F1: after a #range= byte-seek the video's first PTS lands at the GOP
+    boundary (typically 1-3s offset). Subtitle cues land at exact PTS 0 because Emby's
+    startPositionTicks rebases them. Apply +<first_video_pts> as -itsoffset on the
+    subtitle input to align them.
+
+    The probe is mocked here (real ffprobe would hit the network); this test exercises
+    the command-builder logic, not the probe itself.
+    """
+    cfg = BroadcastConfig(
+        network_id="drift_correction",
+        # PHP-rewritten URL with #range= byte-seek.
+        stream_url="http://emby.local/Videos/437/stream.ts?static=true#range=3556648482-",
+        seek_seconds=4444,
+        subtitle_url="http://emby.local/Videos/437/Subtitles/1/Stream.srt",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+
+    # Mock the probe to return 1.483 (the empirically measured GOP drift for item 437).
+    # In a real broadcast this would be ffprobe hitting the network; we stub it here
+    # to isolate the command-builder logic.
+    monkeypatch.setattr(proc, "_probe_video_first_pts", lambda: 1.483)
+
+    cmd = proc._build_ffmpeg_command()
+
+    # The drift-correction -itsoffset +1.483 must be present on the subtitle input.
+    itsoffset_indices = [i for i, arg in enumerate(cmd) if arg == "-itsoffset"]
+    assert itsoffset_indices, "Expected at least one -itsoffset in command"
+    assert any(cmd[i + 1] == "1.483" for i in itsoffset_indices), (
+        f"Expected -itsoffset 1.483 somewhere in command; got: {cmd}"
+    )
+
+
+def test_command_no_drift_correction_when_probe_returns_zero(monkeypatch):
+    """
+    When the probe returns 0 (no meaningful drift, e.g. seek_seconds=0 or
+    server-transcode mode where the server does the seeking), no -itsoffset is
+    added beyond any pre-existing subtitle seek.
+    """
+    cfg = BroadcastConfig(
+        network_id="no_drift",
+        stream_url="http://emby.local/Videos/437/stream.ts?static=true",
+        seek_seconds=0,
+        subtitle_url="http://emby.local/Videos/437/Subtitles/1/Stream.srt",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+    proc._subtitle_language = "eng"
+    proc._subtitle_input_index = 1
+    monkeypatch.setattr(proc, "_probe_video_first_pts", lambda: 0.0)
+
+    cmd = proc._build_ffmpeg_command()
+
+    # No -itsoffset should be added when probe returns 0.
+    assert "-itsoffset" not in cmd
+
+
+def test_probe_video_first_pts_returns_correct_value(monkeypatch):
+    """
+    Verify _probe_video_first_pts() returns the value that ffprobe extracted from the
+    tiny TS chunk that ffmpeg first wrote to disk. Both subprocess.run calls are mocked:
+    the first writes a chunk to a temp file (succeeds silently), the second extracts
+    PTS via ffprobe and returns the value.
+    """
+    cfg = BroadcastConfig(
+        network_id="probe_value",
+        stream_url="http://emby.local/Videos/437/stream.ts#range=3556648482-",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    # ffprobe (the second subprocess.run call) returns PTS in stdout.
+    # ffmpeg (the first call) succeeds silently with empty stdout.
+    def fake_run(cmd, *args, **kwargs):
+        # Heuristic: ffprobe is the one with `packet=pts_time` anywhere in args.
+        cmd_str = " ".join(str(arg) for arg in cmd)
+        if "packet=pts_time" in cmd_str:
+            return MagicMock(returncode=0, stdout="1.483000\n")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pts = proc._probe_video_first_pts()
+
+    assert pts == 1.483
+    # Second call should return the cached value (no second subprocess call).
+    pts2 = proc._probe_video_first_pts()
+    assert pts2 == 1.483

--- a/tests/test_broadcast_subtitles.py
+++ b/tests/test_broadcast_subtitles.py
@@ -802,3 +802,66 @@ def test_probe_video_first_pts_returns_correct_value(monkeypatch):
     # Second call should return the cached value (no second subprocess call).
     pts2 = proc._probe_video_first_pts()
     assert pts2 == 1.483
+
+
+def test_probe_video_first_pts_falls_back_to_audio_when_video_filter_empty(monkeypatch):
+    """
+    Regression test for the bin_data edge case: when ffmpeg's byte-seek lands on a
+    TS fragment where the video stream isn't registered (only `bin_data` and audio),
+    `-select_streams v` returns empty stdout. The probe now omits the video filter
+    and parses the first non-blank parseable PTS line — for MPEG-TS, audio packets
+    arrive at effectively the same GOP-boundary offset as video packets, so the
+    audio PTS is a valid drift proxy.
+    """
+    cfg = BroadcastConfig(
+        network_id="bin_data_fallback",
+        stream_url="http://emby.local/Videos/487/stream.ts?...#range=419108307-",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    # Simulate ffprobe stdout: multiple lines, first is bin_data "N/A",
+    # second is audio packet PTS. Probe should skip N/A and pick audio.
+    def fake_run(cmd, *args, **kwargs):
+        cmd_str = " ".join(str(arg) for arg in cmd)
+        if "packet=pts_time" in cmd_str:
+            return MagicMock(
+                returncode=0,
+                # Real-world shape: bin_data packets have no PTS, audio packets do.
+                stdout="N/A\nN/A\n1.400000\n1.442000\n",
+            )
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pts = proc._probe_video_first_pts()
+
+    # Should pick the first parseable PTS (1.4) even though the first two
+    # lines were N/A (i.e. video/binary packets without PTS metadata).
+    assert pts == 1.4
+
+
+def test_probe_video_first_pts_returns_zero_when_all_lines_unparseable(monkeypatch):
+    """
+    When ffprobe finds NO usable PTS in the captured tmp file (extremely rare;
+    e.g. totally corrupted TS packet), the probe returns 0.0 so callers can
+    safely skip drift correction without crashing.
+    """
+    cfg = BroadcastConfig(
+        network_id="empty_probe",
+        stream_url="http://emby.local/Videos/0/stream.ts#range=0-",
+    )
+    proc = NetworkBroadcastProcess(cfg, hls_base_dir="/tmp")
+
+    def fake_run(cmd, *args, **kwargs):
+        cmd_str = " ".join(str(arg) for arg in cmd)
+        if "packet=pts_time" in cmd_str:
+            # All lines are N/A or empty — probe can't determine PTS.
+            return MagicMock(returncode=0, stdout="N/A\n\nN/A\n")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pts = proc._probe_video_first_pts()
+
+    # No parseable PTS found — return 0.0, caller skips drift correction.
+    assert pts == 0.0


### PR DESCRIPTION
## Summary
Broadcast subsystem: audio stream handling tests and subtitle/seek drift correction. Pairs with m3u-editor single-authority seek work.

## Commits
- \`eecbf26\` test(broadcast): add broadcast audio stream tests
- \`635d730\` feat(api): extend BroadcastStartRequest with subtitle/seek/audio stream fields
- \`bce4588\` fix(broadcast): add -itsoffset drift correction for #range= byte-seek subtitles
- \`50c28de\` feat: include hls_dir in broadcast status response for DVR post-processing *(reverted in \`9569c5d\` — not needed in prod)*

## Notes
- Subtitle drift fix pairs with editor-side \`getSubtitleUrl\` \`server_seeked\` flag.
- The hls_dir commit and its revert are both included; net effect is no hls_dir change.